### PR TITLE
feat: unified document model — drag/save fixed, 8 follow-ups remain

### DIFF
--- a/docs/plans/2026-04-27-unified-document-impl.md
+++ b/docs/plans/2026-04-27-unified-document-impl.md
@@ -12,6 +12,82 @@
 
 ---
 
+## Plan-Review Corrections (Gemini, 2026-04-27)
+
+These corrections override the original task code below. Apply them when implementing each task.
+
+**Task 4 (changeFilter inverted) — CRITICAL.** `EditorState.changeFilter.of` returning an array of numbers specifies the *allowed* ranges, not the suppressed ones. Returning `dominated` would *only* allow edits inside wireframe lines. Replace with a boolean filter that returns `false` when any change intersects a claimed range, and bypass for non-user transactions:
+
+```typescript
+const claimFilter = EditorState.changeFilter.of((tr) => {
+  // Allow programmatic changes (move, resize, delete, add — they aren't user input)
+  if (!tr.isUserEvent("input") && !tr.isUserEvent("delete")) return true;
+  const frames = tr.startState.field(framesField);
+  if (frames.length === 0) return true;
+  const claimed: Array<{ from: number; to: number }> = [];
+  for (const f of frames) {
+    if (f.lineCount === 0) continue;
+    const startLine = tr.startState.doc.lineAt(f.docOffset);
+    const endLineNum = Math.min(startLine.number + f.lineCount - 1, tr.startState.doc.lines);
+    const endLine = tr.startState.doc.line(endLineNum);
+    claimed.push({ from: startLine.from, to: endLine.to });
+  }
+  let intersects = false;
+  tr.changes.iterChangedRanges((fromA, toA) => {
+    for (const r of claimed) {
+      if (fromA <= r.to && toA >= r.from) { intersects = true; break; }
+    }
+  });
+  return !intersects;
+});
+```
+
+**Task 5 (mapPos associativity) — IMPORTANT.** Default `mapPos` associativity is `-1` (stay before insertions). For a frame's `docOffset`, we want it to *follow* preceding insertions (Enter above pushes frame down). Use `tr.changes.mapPos(f.docOffset, 1)`.
+
+**Task 11 (delete merges prose) — CRITICAL.** Removing `[startLine.from - 1, endLine.to + 1]` deletes both the leading and trailing newlines, concatenating prose-above with prose-below. Delete only one newline:
+
+```typescript
+const from = startLine.from > 0 ? startLine.from - 1 : startLine.from;
+const to = endLine.to;  // do not extend past trailing newline
+return [tr, { changes: { from, to }, sequential: true }];
+```
+
+(If frame is at doc start, the trailing newline is the only separator; in that case use `from = 0, to = endLine.to + 1`.)
+
+**Task 12 (drag offset drift) — CRITICAL.** `sequential: true` makes the second spec see the post-delete doc, so `insertAt` becomes invalid. Compute the insertion point in *post-delete* coordinates by mapping it through the deletion:
+
+```typescript
+// After deleting [deleteFrom, deleteTo], characters shift by -(deleteTo - deleteFrom)
+// for any position >= deleteTo. Compute mappedInsertAt accordingly.
+const mappedInsertAt = insertAt > deleteTo
+  ? insertAt - (deleteTo - deleteFrom)
+  : insertAt;
+return [
+  { effects: [...tr.effects, relocateFrameEffect.of({ id: frame.id, newDocOffset: mappedInsertAt })],
+    changes: { from: deleteFrom, to: deleteTo } },
+  { changes: { from: mappedInsertAt, insert: claimedContent + "\n" }, sequential: true },
+];
+```
+
+Prefer a single `changes` array over `sequential: true` when feasible. Test drag-up and drag-down both.
+
+**Task 14 (cursor stuck on adjacent frames) — IMPORTANT.** Replace `if (claimed)` with `while`:
+
+```typescript
+let claimed = getClaimedLineRange(state, targetRow);
+while (claimed) {
+  targetRow = claimed.end + 1;
+  if (targetRow >= state.doc.lines) return state;
+  claimed = getClaimedLineRange(state, targetRow);
+}
+```
+
+Same for `proseMoveUp` (decrement, check `targetRow < 0`).
+
+**Task 15 (do NOT remove gridRow) — CRITICAL.** Child frames use `child.gridRow` for relative positioning inside their parent (see Task 7 `renderFrameRow` line `localRow - child.gridRow`). `docOffset` is a 1D top-level CM offset and cannot replace 2D child positioning. Keep `gridRow` on the Frame interface. Update Task 15's file list to remove only `proseSegmentMap`-related fields, not `gridRow`.
+
+---
+
 ## Phase 1: Frame model — add docOffset/lineCount alongside gridRow (incremental)
 
 ### Task 1: Add docOffset + lineCount to Frame interface

--- a/docs/plans/2026-04-27-unified-document-impl.md
+++ b/docs/plans/2026-04-27-unified-document-impl.md
@@ -86,6 +86,20 @@ Same for `proseMoveUp` (decrement, check `targetRow < 0`).
 
 **Task 15 (do NOT remove gridRow) — CRITICAL.** Child frames use `child.gridRow` for relative positioning inside their parent (see Task 7 `renderFrameRow` line `localRow - child.gridRow`). `docOffset` is a 1D top-level CM offset and cannot replace 2D child positioning. Keep `gridRow` on the Frame interface. Update Task 15's file list to remove only `proseSegmentMap`-related fields, not `gridRow`.
 
+## Sub-agent code-audit corrections (2026-04-27)
+
+**Task 3 (claimed-line filler should be empty string, not single space) — IMPORTANT.** `preparedCache.ts:12` maps `line.length > 0 → non-null`, so claimed lines filled with `" "` produce one spurious `PositionedLine` per row in `linesRef.current`. Empty strings hit the null path and generate no positioned line — and `reflowLayout.ts:98-107` already advances `lineTop` past the obstacle correctly. Use `""` (empty) for claimed lines in `createEditorStateUnified`. Recompute `docOffset` accordingly: empty-line "" is 0 chars, so claimed-line spans become `\n\n\n` (n-1 newlines for n claimed lines + leading newline if any).
+
+**Task 4 (note re-filtering semantics) — DOC.** When `transactionFilter` (Tasks 10–13) returns an array of specs, CM merges them via `resolveTransaction(state, filtered, false)` — the `false` means `changeFilter` is NOT re-applied. So `claimFilter`'s rejection of edits-into-claimed-ranges does NOT block the programmatic delete+insert emitted by the drag transactionFilter. This is correct and intentional — add a comment in `claimFilter` noting this so future maintainers don't try to "fix" it.
+
+**Task 12 (drag undo gap) — IMPORTANT.** No existing test mixes a frame effect WITH a CM doc change in one transaction. Drag is the first such case. Mandatory tests:
+1. Drag down `dRow:2` → undo restores pre-drag doc + pre-drag `docOffset`.
+2. Drag up `dRow:-2` → same. Covers `insertAt < deleteFrom` branch.
+3. After drag, `undoDepth === 1` (one entry covers both doc + frame changes atomically).
+4. Redo after undo restores the post-drag state.
+5. Drag → prose-edit → undo twice. Each undo independent.
+6. After undo, `mapPos` in `framesField.update` runs first but `restoreFramesEffect` overwrites — verify final `docOffset` matches pre-drag snapshot exactly.
+
 ---
 
 ## Phase 1: Frame model — add docOffset/lineCount alongside gridRow (incremental)

--- a/src/DemoV2.tsx
+++ b/src/DemoV2.tsx
@@ -2,7 +2,7 @@
  * DemoV2 — Frame-based spatial canvas. Thin shell using frame.ts + frameRenderer.ts.
  */
 import { useEffect, useRef, useState } from "react";
-import { buildPreparedCache, invalidateLine, splitLine, mergeLines, type PreparedCache } from "./preparedCache";
+import { buildPreparedCache, type PreparedCache } from "./preparedCache";
 import type { EditorState } from "@codemirror/state";
 import { Transaction } from "@codemirror/state";
 import {
@@ -1009,54 +1009,18 @@ export default function DemoV2() {
         if (e.key === "Backspace") {
           e.preventDefault();
           const beforeCursor = getCursor(stateRef.current)!;
-          const isLineMerge = beforeCursor.col === 0 && beforeCursor.row > 0;
           stateRef.current = proseDeleteBefore(stateRef.current, beforeCursor);
-          proseRef.current = getDoc(stateRef.current);
+          // Unified-doc: proseDelete mutates the CM doc; mapPos in framesField
+          // shifts every frame's docOffset automatically. No manual frame-shift
+          // loop needed. syncRefsFromState rebuilds preparedRef from scratch.
           syncRefsFromState();
-          const afterCursor = getCursor(stateRef.current)!;
-          if (isLineMerge) {
-            mergeLines(preparedRef.current, beforeCursor.row, stateRef.current.doc.line(afterCursor.row + 1).text);
-            // Shift frames up when a line is deleted via merge
-            // In unified doc, cursor.row IS the source/grid row directly
-            const mergeGridRow = beforeCursor.row;
-            const ch = chRef.current;
-            const cw = cwRef.current;
-            for (const f of framesRef.current) {
-              if (f.gridRow >= mergeGridRow) {
-                stateRef.current = stateRef.current.update({
-                  effects: moveFrameEffect.of({ id: f.id, dCol: 0, dRow: -1, charWidth: cw, charHeight: ch }),
-                }).state;
-              }
-            }
-            syncRefsFromState();
-          } else {
-            invalidateLine(preparedRef.current, afterCursor.row, stateRef.current.doc.line(afterCursor.row + 1).text);
-          }
-          proseCursorRef.current = afterCursor;
+          proseCursorRef.current = getCursor(stateRef.current);
           scheduleAutosave(); doLayout(); blinkRef.current = true; paint(); return;
         }
         if (e.key === "Enter") {
           e.preventDefault();
-          const beforeRow = getCursor(stateRef.current)!.row;
           stateRef.current = proseInsert(stateRef.current, getCursor(stateRef.current)!, "\n");
-          proseRef.current = getDoc(stateRef.current);
-          syncRefsFromState();
-          // Split: beforeRow keeps text before cursor, beforeRow+1 gets text after
-          const firstText = stateRef.current.doc.line(beforeRow + 1).text;
-          const secondText = stateRef.current.doc.line(beforeRow + 2).text;
-          splitLine(preparedRef.current, beforeRow, firstText, secondText);
-          // Shift frames down when a new line is inserted
-          // In unified doc, beforeRow IS the source/grid row directly
-          const editGridRow = beforeRow;
-          const ch = chRef.current;
-          const cw = cwRef.current;
-          for (const f of framesRef.current) {
-            if (f.gridRow >= editGridRow) {
-              stateRef.current = stateRef.current.update({
-                effects: moveFrameEffect.of({ id: f.id, dCol: 0, dRow: 1, charWidth: cw, charHeight: ch }),
-              }).state;
-            }
-          }
+          // Same as Backspace: unified pipeline handles both doc + frame shift.
           syncRefsFromState();
           proseCursorRef.current = getCursor(stateRef.current);
           scheduleAutosave(); doLayout(); blinkRef.current = true; paint(); return;
@@ -1064,11 +1028,8 @@ export default function DemoV2() {
         if (e.key.length === 1 && !mod) {
           e.preventDefault();
           stateRef.current = proseInsert(stateRef.current, getCursor(stateRef.current)!, e.key);
-          proseRef.current = getDoc(stateRef.current);
           syncRefsFromState();
-          const cur = getCursor(stateRef.current)!;
-          invalidateLine(preparedRef.current, cur.row, stateRef.current.doc.line(cur.row + 1).text);
-          proseCursorRef.current = cur;
+          proseCursorRef.current = getCursor(stateRef.current);
           scheduleAutosave(); doLayout(); blinkRef.current = true; paint(); return;
         }
         return;

--- a/src/DemoV2.tsx
+++ b/src/DemoV2.tsx
@@ -210,7 +210,7 @@ export default function DemoV2() {
       await w.write(md);
       await w.close();
       stateRef.current = applyClearDirty(stateRef.current);
-      framesRef.current = getFrames(stateRef.current);
+      syncRefsFromState();
     } catch (err) { console.error("saveToHandle failed:", err); }
   }
   function scheduleAutosave() {
@@ -223,14 +223,19 @@ export default function DemoV2() {
   function loadDocument(text: string) {
     const cw = cwRef.current, ch = chRef.current;
     stateRef.current = createEditorStateUnified(text, cw, ch);
-    // Sync old refs for un-migrated code paths
-    const frames = getFrames(stateRef.current);
-    const proseText = getDoc(stateRef.current);
-    proseRef.current = proseText;
-    framesRef.current = frames;
-    preparedRef.current = buildPreparedCache(proseText);
+    syncRefsFromState();
     dragRef.current = null;
     proseCursorRef.current = null;
+  }
+
+  /** Refresh framesRef + proseRef + preparedRef from the current EditorState.
+   * Call after any mutation that goes through unifiedDocSync (drag, resize,
+   * delete, add) so the prepared-line cache reflects the post-mutation doc. */
+  function syncRefsFromState() {
+    const proseText = getDoc(stateRef.current);
+    proseRef.current = proseText;
+    framesRef.current = getFrames(stateRef.current);
+    preparedRef.current = buildPreparedCache(proseText);
   }
 
   function doLayout() {
@@ -601,7 +606,7 @@ export default function DemoV2() {
         effects,
         annotations: [Transaction.addToHistory.of(isFirstDragStep)],
       }).state;
-      framesRef.current = getFrames(stateRef.current);
+      syncRefsFromState();
     } else {
       // Compute target position from drag start + mouse delta, snapped to grid
       const cw = cwRef.current, ch = chRef.current;
@@ -616,7 +621,7 @@ export default function DemoV2() {
           effects: moveFrameEffect.of({ id: drag.frameId, dCol, dRow, charWidth: cw, charHeight: ch }),
           annotations: [Transaction.addToHistory.of(isFirstDragStep)],
         }).state;
-        framesRef.current = getFrames(stateRef.current);
+        syncRefsFromState();
       }
     }
     doLayout(); paint();
@@ -645,12 +650,12 @@ export default function DemoV2() {
       const f = createRectFrame({ gridW: Math.max(2, Math.round((x2 - x1) / cw)), gridH: Math.max(2, Math.round((y2 - y1) / ch)), style: { tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│" }, charWidth: cw, charHeight: ch });
       const gridR = Math.round(y1 / ch), gridC = Math.round(x1 / cw);
       stateRef.current = applyAddFrame(stateRef.current, { ...f, x: gridC * cw, y: gridR * ch, gridRow: gridR, gridCol: gridC });
-      framesRef.current = getFrames(stateRef.current); scheduleAutosave();
+      syncRefsFromState(); scheduleAutosave();
     } else if (tool === "line") {
       const r1 = Math.round(preview.startY / ch), c1 = Math.round(preview.startX / cw), r2 = Math.round(preview.curY / ch), c2 = Math.round(preview.curX / cw);
       if (r1 !== r2 || c1 !== c2) {
         stateRef.current = applyAddFrame(stateRef.current, createLineFrame({ r1, c1, r2, c2, charWidth: cw, charHeight: ch }));
-        framesRef.current = getFrames(stateRef.current); scheduleAutosave();
+        syncRefsFromState(); scheduleAutosave();
       }
     }
     setTool("select"); // one-shot: revert to Select after drawing
@@ -674,7 +679,7 @@ export default function DemoV2() {
           const state = stateRef.current;
           const md = serializeUnified(getDoc(state), getFrames(state));
           stateRef.current = applyClearDirty(stateRef.current);
-          framesRef.current = getFrames(stateRef.current);
+          syncRefsFromState();
           doLayout(); paint();
           return md;
         },
@@ -745,7 +750,7 @@ export default function DemoV2() {
           }).state;
           proseCursorRef.current = null;
           textEditRef.current = null;
-          framesRef.current = getFrames(stateRef.current);
+          syncRefsFromState();
           paint();
         },
       };
@@ -772,7 +777,7 @@ export default function DemoV2() {
       if (mod && e.key === "z" && !e.shiftKey) {
         e.preventDefault();
         stateRef.current = editorUndo(stateRef.current);
-        framesRef.current = getFrames(stateRef.current);
+        syncRefsFromState();
         proseRef.current = getDoc(stateRef.current);
         preparedRef.current = buildPreparedCache(proseRef.current);
         proseCursorRef.current = getCursor(stateRef.current);
@@ -782,7 +787,7 @@ export default function DemoV2() {
       if (mod && e.key === "z" && e.shiftKey) {
         e.preventDefault();
         stateRef.current = editorRedo(stateRef.current);
-        framesRef.current = getFrames(stateRef.current);
+        syncRefsFromState();
         proseRef.current = getDoc(stateRef.current);
         preparedRef.current = buildPreparedCache(proseRef.current);
         proseCursorRef.current = getCursor(stateRef.current);
@@ -828,7 +833,7 @@ export default function DemoV2() {
           if (tp.chars.length > 0) {
             const cw = cwRef.current, ch = chRef.current;
             stateRef.current = applyAddFrame(stateRef.current, createTextFrame({ text: tp.chars, row: Math.round(tp.y / ch), col: Math.round(tp.x / cw), charWidth: cw, charHeight: ch }));
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             scheduleAutosave(); doLayout();
           }
           setTool("select"); paint(); return; // one-shot: revert to Select
@@ -854,7 +859,7 @@ export default function DemoV2() {
             stateRef.current = stateRef.current.update({
               effects: setTextAlignEffect.of({ id: te.frameId, hAlign: { anchor: "left", offset: 0 }, charWidth: cwRef.current, charHeight: chRef.current }),
             }).state;
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             blinkRef.current = true; paint(); return;
           }
           if (e.key === "e" || e.key === "E") {
@@ -862,7 +867,7 @@ export default function DemoV2() {
             stateRef.current = stateRef.current.update({
               effects: setTextAlignEffect.of({ id: te.frameId, hAlign: { anchor: "center", offset: 0 }, charWidth: cwRef.current, charHeight: chRef.current }),
             }).state;
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             blinkRef.current = true; paint(); return;
           }
           if (e.key === "r" || e.key === "R") {
@@ -870,7 +875,7 @@ export default function DemoV2() {
             stateRef.current = stateRef.current.update({
               effects: setTextAlignEffect.of({ id: te.frameId, hAlign: { anchor: "right", offset: 0 }, charWidth: cwRef.current, charHeight: chRef.current }),
             }).state;
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             blinkRef.current = true; paint(); return;
           }
         }
@@ -880,7 +885,7 @@ export default function DemoV2() {
             stateRef.current = stateRef.current.update({
               effects: setTextAlignEffect.of({ id: te.frameId, vAlign: { anchor: "top", offset: 0 }, charWidth: cwRef.current, charHeight: chRef.current }),
             }).state;
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             blinkRef.current = true; paint(); return;
           }
           if (e.key === "m" || e.key === "M") {
@@ -888,7 +893,7 @@ export default function DemoV2() {
             stateRef.current = stateRef.current.update({
               effects: setTextAlignEffect.of({ id: te.frameId, vAlign: { anchor: "center", offset: 0 }, charWidth: cwRef.current, charHeight: chRef.current }),
             }).state;
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             blinkRef.current = true; paint(); return;
           }
           if (e.key === "b" || e.key === "B") {
@@ -896,7 +901,7 @@ export default function DemoV2() {
             stateRef.current = stateRef.current.update({
               effects: setTextAlignEffect.of({ id: te.frameId, vAlign: { anchor: "bottom", offset: 0 }, charWidth: cwRef.current, charHeight: chRef.current }),
             }).state;
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             blinkRef.current = true; paint(); return;
           }
         }
@@ -951,7 +956,7 @@ export default function DemoV2() {
               ],
               annotations: [Transaction.addToHistory.of(true)],
             }).state;
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
             textEditRef.current = getTextEdit(stateRef.current);
             scheduleAutosave();
           }
@@ -969,7 +974,7 @@ export default function DemoV2() {
             ],
             annotations: [Transaction.addToHistory.of(true)],
           }).state;
-          framesRef.current = getFrames(stateRef.current);
+          syncRefsFromState();
           textEditRef.current = getTextEdit(stateRef.current);
           scheduleAutosave(); blinkRef.current = true; paint(); return;
         }
@@ -1007,7 +1012,7 @@ export default function DemoV2() {
           const isLineMerge = beforeCursor.col === 0 && beforeCursor.row > 0;
           stateRef.current = proseDeleteBefore(stateRef.current, beforeCursor);
           proseRef.current = getDoc(stateRef.current);
-          framesRef.current = getFrames(stateRef.current);
+          syncRefsFromState();
           const afterCursor = getCursor(stateRef.current)!;
           if (isLineMerge) {
             mergeLines(preparedRef.current, beforeCursor.row, stateRef.current.doc.line(afterCursor.row + 1).text);
@@ -1023,7 +1028,7 @@ export default function DemoV2() {
                 }).state;
               }
             }
-            framesRef.current = getFrames(stateRef.current);
+            syncRefsFromState();
           } else {
             invalidateLine(preparedRef.current, afterCursor.row, stateRef.current.doc.line(afterCursor.row + 1).text);
           }
@@ -1035,7 +1040,7 @@ export default function DemoV2() {
           const beforeRow = getCursor(stateRef.current)!.row;
           stateRef.current = proseInsert(stateRef.current, getCursor(stateRef.current)!, "\n");
           proseRef.current = getDoc(stateRef.current);
-          framesRef.current = getFrames(stateRef.current);
+          syncRefsFromState();
           // Split: beforeRow keeps text before cursor, beforeRow+1 gets text after
           const firstText = stateRef.current.doc.line(beforeRow + 1).text;
           const secondText = stateRef.current.doc.line(beforeRow + 2).text;
@@ -1052,7 +1057,7 @@ export default function DemoV2() {
               }).state;
             }
           }
-          framesRef.current = getFrames(stateRef.current);
+          syncRefsFromState();
           proseCursorRef.current = getCursor(stateRef.current);
           scheduleAutosave(); doLayout(); blinkRef.current = true; paint(); return;
         }
@@ -1060,7 +1065,7 @@ export default function DemoV2() {
           e.preventDefault();
           stateRef.current = proseInsert(stateRef.current, getCursor(stateRef.current)!, e.key);
           proseRef.current = getDoc(stateRef.current);
-          framesRef.current = getFrames(stateRef.current);
+          syncRefsFromState();
           const cur = getCursor(stateRef.current)!;
           invalidateLine(preparedRef.current, cur.row, stateRef.current.doc.line(cur.row + 1).text);
           proseCursorRef.current = cur;
@@ -1076,7 +1081,7 @@ export default function DemoV2() {
       const deleteSelectedId = getSelectedId(stateRef.current);
       if ((e.key === "Delete" || e.key === "Backspace") && deleteSelectedId) {
         stateRef.current = applyDeleteFrame(stateRef.current, deleteSelectedId);
-        framesRef.current = getFrames(stateRef.current);
+        syncRefsFromState();
         doLayout(); paint();
       }
       // Z-order shortcuts (top-level frames only)
@@ -1087,23 +1092,23 @@ export default function DemoV2() {
           if (e.key === "]" && !mod) {
             e.preventDefault();
             stateRef.current = stateRef.current.update({ effects: setZEffect.of({ id: topFrame.id, z: topFrame.z + 1 }), annotations: [Transaction.addToHistory.of(true)] }).state;
-            framesRef.current = getFrames(stateRef.current); doLayout(); paint(); return;
+            syncRefsFromState(); doLayout(); paint(); return;
           }
           if (e.key === "[" && !mod) {
             e.preventDefault();
             stateRef.current = stateRef.current.update({ effects: setZEffect.of({ id: topFrame.id, z: Math.max(0, topFrame.z - 1) }), annotations: [Transaction.addToHistory.of(true)] }).state;
-            framesRef.current = getFrames(stateRef.current); doLayout(); paint(); return;
+            syncRefsFromState(); doLayout(); paint(); return;
           }
           if (e.key === "]" && mod) {
             e.preventDefault();
             const maxZ = Math.max(...framesRef.current.map(f => f.z));
             stateRef.current = stateRef.current.update({ effects: setZEffect.of({ id: topFrame.id, z: maxZ + 1 }), annotations: [Transaction.addToHistory.of(true)] }).state;
-            framesRef.current = getFrames(stateRef.current); doLayout(); paint(); return;
+            syncRefsFromState(); doLayout(); paint(); return;
           }
           if (e.key === "[" && mod) {
             e.preventDefault();
             stateRef.current = stateRef.current.update({ effects: setZEffect.of({ id: topFrame.id, z: 0 }), annotations: [Transaction.addToHistory.of(true)] }).state;
-            framesRef.current = getFrames(stateRef.current); doLayout(); paint(); return;
+            syncRefsFromState(); doLayout(); paint(); return;
           }
         }
       }

--- a/src/DemoV2.tsx
+++ b/src/DemoV2.tsx
@@ -6,19 +6,17 @@ import { buildPreparedCache, invalidateLine, splitLine, mergeLines, type Prepare
 import type { EditorState } from "@codemirror/state";
 import { Transaction } from "@codemirror/state";
 import {
-  createEditorStateFromText, getDoc, getFrames,
+  createEditorStateUnified, getDoc, getFrames,
   selectFrameEffect, getSelectedId,
   moveFrameEffect, resizeFrameEffect, setZEffect,
-  applyAddFrame, applyDeleteFrame, applyClearDirty, applySetOriginalProseSegments,
+  applyAddFrame, applyDeleteFrame, applyClearDirty,
   proseInsert, proseDeleteBefore, moveCursorTo, getCursor,
   proseMoveLeft, proseMoveRight, proseMoveUp, proseMoveDown,
   editorUndo, editorRedo,
-  getProseSegmentMap, getOriginalProseSegments,
   setTextEditEffect, editTextFrameEffect, getTextEdit,
   type CursorPos,
 } from "./editorState";
-import { gridSerialize, rebuildOriginalGrid, snapshotFrameBboxes, framesToProseGaps, type FrameBbox } from "./gridSerialize";
-import { scanToFrames } from "./scanToFrames";
+import { serializeUnified } from "./serializeUnified";
 import { type Frame, hitTestFrames, resizeFrame, createRectFrame, createLineFrame, createTextFrame } from "./frame";
 import { renderFrame, renderFrameSelection } from "./frameRenderer";
 import { setTextAlignEffect } from "./editorState";
@@ -201,30 +199,18 @@ export default function DemoV2() {
   const textPlacementRef = useRef<{ x: number; y: number; chars: string } | null>(null);
   const fileHandleRef = useRef<FileSystemFileHandle | null>(null);
   const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const originalGridRef = useRef<string[][]>([]);
-  const frameBboxSnapshotRef = useRef<FrameBbox[]>([]);
 
   type WritableHandle = FileSystemFileHandle & { createWritable(): Promise<FileSystemWritableFileStream> };
   async function saveToHandle(h: FileSystemFileHandle) {
     console.log("saveToHandle called, handle:", h.name);
     try {
       const state = stateRef.current;
-      const md = gridSerialize(
-        getFrames(state), getDoc(state),
-        originalGridRef.current,
-        getOriginalProseSegments(state),
-        frameBboxSnapshotRef.current,
-      );
+      const md = serializeUnified(getDoc(state), getFrames(state));
       const w = await (h as WritableHandle).createWritable();
       await w.write(md);
       await w.close();
       stateRef.current = applyClearDirty(stateRef.current);
-      // Rebuild originalProseSegments from saved output
-      const { proseSegments: newSegs } = scanToFrames(md, cwRef.current, chRef.current);
-      stateRef.current = applySetOriginalProseSegments(stateRef.current, newSegs);
       framesRef.current = getFrames(stateRef.current);
-      originalGridRef.current = rebuildOriginalGrid(md);
-      frameBboxSnapshotRef.current = snapshotFrameBboxes(getFrames(stateRef.current));
     } catch (err) { console.error("saveToHandle failed:", err); }
   }
   function scheduleAutosave() {
@@ -236,10 +222,7 @@ export default function DemoV2() {
 
   function loadDocument(text: string) {
     const cw = cwRef.current, ch = chRef.current;
-    stateRef.current = createEditorStateFromText(text, cw, ch);
-    const { originalGrid } = scanToFrames(text, cw, ch);
-    originalGridRef.current = originalGrid;
-    frameBboxSnapshotRef.current = snapshotFrameBboxes(getFrames(stateRef.current));
+    stateRef.current = createEditorStateUnified(text, cw, ch);
     // Sync old refs for un-migrated code paths
     const frames = getFrames(stateRef.current);
     const proseText = getDoc(stateRef.current);
@@ -251,21 +234,44 @@ export default function DemoV2() {
   }
 
   function doLayout() {
-    if (preparedRef.current.length === 0) { linesRef.current = []; return; }
+    if (!stateRef.current) { linesRef.current = []; return; }
     const ch = chRef.current;
-    const sorted = [...framesRef.current].sort((a, b) => a.gridRow - b.gridRow);
-    const merged: { y: number; bottom: number }[] = [];
-    for (const f of sorted) {
-      const fy = f.gridRow * ch;
-      const fb = fy + f.gridH * ch;
-      if (merged.length > 0 && fy <= merged[merged.length - 1].bottom) {
-        merged[merged.length - 1].bottom = Math.max(merged[merged.length - 1].bottom, fb);
+    const frames = getFrames(stateRef.current);
+
+    // Build set of claimed line numbers (0-based)
+    const claimedLines = new Set<number>();
+    for (const f of frames) {
+      if (f.lineCount === 0) continue;
+      const startLine = stateRef.current.doc.lineAt(f.docOffset).number - 1;
+      for (let i = 0; i < f.lineCount; i++) claimedLines.add(startLine + i);
+    }
+
+    // Build preparedLines: null for claimed lines, prepared text for prose
+    const prepared = preparedRef.current;
+    const adjusted = prepared.map((p, i) => claimedLines.has(i) ? null : p);
+
+    // No obstacles in unified mode
+    linesRef.current = reflowLayout(adjusted, sizeRef.current.w, ch, []).lines;
+
+    // Set frame pixel Y from lineTop accumulator
+    let lineTop = 0;
+    const doc = stateRef.current.doc;
+    for (let i = 0; i < doc.lines; i++) {
+      if (claimedLines.has(i)) {
+        for (const f of frames) {
+          if (f.lineCount === 0) continue;
+          const startLine = doc.lineAt(f.docOffset).number - 1;
+          if (i === startLine) {
+            f.y = lineTop;
+            f.x = f.gridCol * cwRef.current;
+          }
+        }
+        lineTop += ch;
       } else {
-        merged.push({ y: fy, bottom: fb });
+        const visualLines = linesRef.current.filter(l => l.sourceLine === i);
+        lineTop += Math.max(visualLines.length, 1) * ch;
       }
     }
-    const obstacles = merged.map(m => ({ x: 0, y: m.y, w: sizeRef.current.w, h: m.bottom - m.y }));
-    linesRef.current = reflowLayout(preparedRef.current, sizeRef.current.w, ch, obstacles).lines;
   }
 
   function paint() {
@@ -661,30 +667,14 @@ export default function DemoV2() {
         loadDocument: (text: string) => { loadDocument(text); doLayout(); paint(); },
         serializeDocument: () => {
           const state = stateRef.current;
-          return gridSerialize(
-            getFrames(state), getDoc(state),
-            originalGridRef.current,
-            getOriginalProseSegments(state),
-            frameBboxSnapshotRef.current,
-          );
+          return serializeUnified(getDoc(state), getFrames(state));
         },
         /** Serialize + update all refs (mirrors real saveToHandle minus file I/O) */
         saveDocument: () => {
           const state = stateRef.current;
-          const cw = cwRef.current, ch = chRef.current;
-          const md = gridSerialize(
-            getFrames(state), getDoc(state),
-            originalGridRef.current,
-            getOriginalProseSegments(state),
-            frameBboxSnapshotRef.current,
-          );
-          // Same ref updates as saveToHandle
+          const md = serializeUnified(getDoc(state), getFrames(state));
           stateRef.current = applyClearDirty(stateRef.current);
-          const { proseSegments: newSegs } = scanToFrames(md, cw, ch);
-          stateRef.current = applySetOriginalProseSegments(stateRef.current, newSegs);
           framesRef.current = getFrames(stateRef.current);
-          originalGridRef.current = rebuildOriginalGrid(md);
-          frameBboxSnapshotRef.current = snapshotFrameBboxes(getFrames(stateRef.current));
           doLayout(); paint();
           return md;
         },
@@ -1022,8 +1012,8 @@ export default function DemoV2() {
           if (isLineMerge) {
             mergeLines(preparedRef.current, beforeCursor.row, stateRef.current.doc.line(afterCursor.row + 1).text);
             // Shift frames up when a line is deleted via merge
-            const segMap = getProseSegmentMap(stateRef.current);
-            const mergeGridRow = segMap[beforeCursor.row]?.row ?? beforeCursor.row;
+            // In unified doc, cursor.row IS the source/grid row directly
+            const mergeGridRow = beforeCursor.row;
             const ch = chRef.current;
             const cw = cwRef.current;
             for (const f of framesRef.current) {
@@ -1051,8 +1041,8 @@ export default function DemoV2() {
           const secondText = stateRef.current.doc.line(beforeRow + 2).text;
           splitLine(preparedRef.current, beforeRow, firstText, secondText);
           // Shift frames down when a new line is inserted
-          const segMap = getProseSegmentMap(stateRef.current);
-          const editGridRow = segMap[beforeRow]?.row ?? beforeRow;
+          // In unified doc, beforeRow IS the source/grid row directly
+          const editGridRow = beforeRow;
           const ch = chRef.current;
           const cw = cwRef.current;
           for (const f of framesRef.current) {

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1643,3 +1643,115 @@ describe("Enter/Backspace above wireframe (should work via mapPos)", () => {
     expect(getDoc(s)).toBe(getDoc(state));
   });
 });
+
+// ── Task 10: Resize wireframe inserts/removes claimed lines ────────────────
+
+describe("resize wireframe in unified mode", () => {
+  it("resize taller inserts blank claimed lines and updates lineCount", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    expect(before.lineCount).toBe(3);
+    const docLinesBefore = state.doc.lines;
+    const updated = state.update({
+      effects: resizeFrameEffect.of({
+        id: before.id, gridW: before.gridW, gridH: 5,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(updated)[0];
+    expect(after.lineCount).toBe(5);
+    expect(after.gridH).toBe(5);
+    expect(updated.doc.lines).toBe(docLinesBefore + 2);
+  });
+
+  it("resize shorter removes claimed lines and updates lineCount", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n│    │\n│    │\n└────┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    expect(before.lineCount).toBe(5);
+    const docLinesBefore = state.doc.lines;
+    const updated = state.update({
+      effects: resizeFrameEffect.of({
+        id: before.id, gridW: before.gridW, gridH: 3,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(updated)[0];
+    expect(after.lineCount).toBe(3);
+    expect(after.gridH).toBe(3);
+    expect(updated.doc.lines).toBe(docLinesBefore - 2);
+  });
+
+  it("resize-no-change does not touch the doc", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    const docBefore = getDoc(state);
+    const updated = state.update({
+      effects: resizeFrameEffect.of({
+        id: before.id, gridW: before.gridW, gridH: 3,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    expect(getDoc(updated)).toBe(docBefore);
+    expect(getFrames(updated)[0].lineCount).toBe(3);
+  });
+
+  it("resize taller is undoable — doc and lineCount restored", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    const docBefore = getDoc(state);
+    let s = state.update({
+      effects: resizeFrameEffect.of({
+        id: before.id, gridW: before.gridW, gridH: 5,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    expect(getFrames(s)[0].lineCount).toBe(5);
+    s = editorUndo(s);
+    expect(getDoc(s)).toBe(docBefore);
+    expect(getFrames(s)[0].lineCount).toBe(3);
+  });
+
+  it("resize preserves docOffset (frame stays at its anchor line)", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    const updated = state.update({
+      effects: resizeFrameEffect.of({
+        id: before.id, gridW: before.gridW, gridH: 5,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(updated)[0];
+    expect(after.docOffset).toBe(before.docOffset);
+  });
+
+  it("inserted claimed lines are empty strings (preparedCache null fast-path)", () => {
+    // Per Task 3 plan correction: claimed lines must be "" not " "
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    const updated = state.update({
+      effects: resizeFrameEffect.of({
+        id: before.id, gridW: before.gridW, gridH: 5,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(updated)[0];
+    // The new claimed lines should be "" — read all 5 claimed lines.
+    const startLine = updated.doc.lineAt(after.docOffset).number;
+    for (let i = 0; i < after.lineCount; i++) {
+      const line = updated.doc.line(startLine + i);
+      expect(line.text).toBe("");
+    }
+  });
+});

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -40,7 +40,7 @@ import {
   applySetOriginalProseSegments,
   type CursorPos,
 } from "./editorState";
-import { createFrame, createTextFrame, type Frame } from "./frame";
+import { createFrame, createTextFrame, createRectFrame, type Frame } from "./frame";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -1753,5 +1753,230 @@ describe("resize wireframe in unified mode", () => {
       const line = updated.doc.line(startLine + i);
       expect(line.text).toBe("");
     }
+  });
+});
+
+// ── Task 11: delete wireframe in unified mode ─────────────────────────────────
+
+describe("delete wireframe in unified mode", () => {
+  it("deleting a frame removes its claimed lines from CM doc", () => {
+    // "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld" → 5 lines → after delete → 2 lines "Hello\nWorld"
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    expect(state.doc.lines).toBe(5);
+    const frame = getFrames(state)[0];
+    const after = applyDeleteFrame(state, frame.id);
+    expect(getDoc(after)).toBe("Hello\nWorld");
+    expect(after.doc.lines).toBe(2);
+    expect(getFrames(after)).toHaveLength(0);
+  });
+
+  it("deleting frame at file start removes claimed lines + their trailing newline", () => {
+    // "┌────┐\n│ Bx │\n└────┘\nWorld" → after delete → "World"
+    const text = "┌────┐\n│ Bx │\n└────┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    const after = applyDeleteFrame(state, frame.id);
+    expect(getDoc(after)).toBe("World");
+    expect(getFrames(after)).toHaveLength(0);
+  });
+
+  it("deleting frame at file end removes claimed lines + their leading newline", () => {
+    // "Hello\n┌────┐\n│ Bx │\n└────┘" → after delete → "Hello"
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    const after = applyDeleteFrame(state, frame.id);
+    expect(getDoc(after)).toBe("Hello");
+    expect(getFrames(after)).toHaveLength(0);
+  });
+
+  it("deleting frame is undoable — doc and frames restored", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const origDoc = getDoc(state);
+    const origFrameId = getFrames(state)[0].id;
+    const afterDelete = applyDeleteFrame(state, origFrameId);
+    expect(getFrames(afterDelete)).toHaveLength(0);
+    const afterUndo = editorUndo(afterDelete);
+    expect(getDoc(afterUndo)).toBe(origDoc);
+    expect(getFrames(afterUndo)).toHaveLength(1);
+    expect(getFrames(afterUndo)[0].id).toBe(origFrameId);
+  });
+
+  it("deleting one of two frames preserves the other's docOffset relative to its line", () => {
+    // Build two frames manually so we don't rely on scanner behavior.
+    // doc: "Above\n\n\n\nMiddle\n\n\n\nBelow" (each "\n\n\n" = 3 claimed lines for each frame)
+    // Frame 1 claims lines 2-4 (0-indexed gridRow=1, lineCount=3, docOffset=6 "Above\n" = 6)
+    // Frame 2 claims lines 6-8 (0-indexed gridRow=5, lineCount=3, docOffset after "Above\n\n\n\nMiddle\n" = 18)
+    const prose = "Above\n\n\n\nMiddle\n\n\n\nBelow";
+    const f1 = { ...createFrame({ x: 0, y: 18, w: 58, h: 54 }), lineCount: 3, docOffset: 6 };
+    const f2 = { ...createFrame({ x: 0, y: 108, w: 58, h: 54 }), lineCount: 3, docOffset: 18 };
+    const state = createEditorState({ prose, frames: [f1, f2] });
+    expect(getFrames(state)).toHaveLength(2);
+    const after = applyDeleteFrame(state, f1.id);
+    expect(getFrames(after)).toHaveLength(1);
+    const remaining = getFrames(after)[0];
+    expect(remaining.id).toBe(f2.id);
+    // docOffset must be in-bounds for the updated doc
+    expect(remaining.docOffset).toBeGreaterThanOrEqual(0);
+    expect(remaining.docOffset).toBeLessThanOrEqual(after.doc.length);
+    // The line at the new docOffset should still be an empty claimed line
+    expect(after.doc.lineAt(remaining.docOffset).text).toBe("");
+  });
+
+  it("deleting child frame inside container does NOT touch CM doc", () => {
+    // Child frames have lineCount === 0, so the filter must skip them.
+    // Use a parent rect frame with a text child — parent has content so cascade won't remove it.
+    const parent = createRectFrame({ gridW: 10, gridH: 6, style: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" }, charWidth: 9.6, charHeight: 18 });
+    const child = createTextFrame({ text: "hi", row: 1, col: 1, charWidth: 9.6, charHeight: 18 });
+    const childWithLineCount = { ...child, lineCount: 0 };
+    const parentWithChild = { ...parent, lineCount: 3, docOffset: 0, children: [childWithLineCount] };
+    const prose = "\n\n\nSome prose";
+    const state = createEditorState({ prose, frames: [parentWithChild] });
+    const docBefore = getDoc(state);
+    // Delete only the child
+    const after = applyDeleteFrame(state, child.id);
+    // Doc must be unchanged — child deletion doesn't affect CM doc
+    expect(getDoc(after)).toBe(docBefore);
+    // Parent still present, child gone
+    const remaining = getFrames(after);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].children).toHaveLength(0);
+  });
+
+  it("prose lines surrounding the deleted frame are joined cleanly (single newline)", () => {
+    // "Above\n┌──┐\n└──┘\nBelow" → after delete → "Above\nBelow" exactly
+    const text = "Above\n┌──┐\n└──┘\nBelow";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    const after = applyDeleteFrame(state, frame.id);
+    expect(getDoc(after)).toBe("Above\nBelow");
+  });
+});
+
+// ── Task 14: cursor skips claimed line ranges ─────────────────────────────────
+
+describe("cursor skips claimed lines (Task 14)", () => {
+  it("proseMoveDown skips a 3-line wireframe", () => {
+    // Doc: line0=prose, lines1-3=wireframe, line4=prose
+    const text = `Hello
+┌────┐
+│ Bx │
+└────┘
+World`;
+    const cw = 9.6, ch = 18;
+    let state = createEditorStateUnified(text, cw, ch);
+    state = moveCursorTo(state, { row: 0, col: 5 });
+    state = proseMoveDown(state);
+    const cursor = getCursor(state);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.row).toBe(4); // skipped lines 1-3
+  });
+
+  it("proseMoveUp skips a 3-line wireframe", () => {
+    const text = `Hello
+┌────┐
+│ Bx │
+└────┘
+World`;
+    const cw = 9.6, ch = 18;
+    let state = createEditorStateUnified(text, cw, ch);
+    state = moveCursorTo(state, { row: 4, col: 0 });
+    state = proseMoveUp(state);
+    const cursor = getCursor(state);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.row).toBe(0); // skipped lines 1-3
+  });
+
+  it("proseMoveDown skips two adjacent wireframes (regression: while-loop, not if)", () => {
+    // Build state manually with two frames: frame1 claims lines 1-3, frame2 claims lines 4-6.
+    // Prose: line0="prose-line-0", lines 1-6="", line7="prose-line-7"
+    const prose = "prose-line-0\n\n\n\n\n\n\nprose-line-7";
+    // frame1: claims lines 1-3, docOffset = offset of line 1
+    // line0 = "prose-line-0" (12 chars) + newline = 13 chars, so line1 starts at offset 13
+    const frame1: Frame = {
+      ...createFrame({ x: 0, y: 18, w: 96, h: 54 }),
+      gridRow: 1, gridCol: 0, gridW: 10, gridH: 3,
+      docOffset: 13, lineCount: 3,
+    };
+    // line4 starts at: 13 (line1 start) + 3 lines of "" + 3 newlines = 13 + 3 = 16
+    const frame2: Frame = {
+      ...createFrame({ x: 0, y: 72, w: 96, h: 54 }),
+      gridRow: 4, gridCol: 0, gridW: 10, gridH: 3,
+      docOffset: 16, lineCount: 3,
+    };
+    const state = createEditorState({ prose, frames: [frame1, frame2] });
+    let s = moveCursorTo(state, { row: 0, col: 0 });
+    s = proseMoveDown(s);
+    const cursor = getCursor(s);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.row).toBe(7); // skipped lines 1-6 (two adjacent wireframes)
+  });
+
+  it("proseMoveUp skips two adjacent wireframes (regression: while-loop, not if)", () => {
+    const prose = "prose-line-0\n\n\n\n\n\n\nprose-line-7";
+    const frame1: Frame = {
+      ...createFrame({ x: 0, y: 18, w: 96, h: 54 }),
+      gridRow: 1, gridCol: 0, gridW: 10, gridH: 3,
+      docOffset: 13, lineCount: 3,
+    };
+    const frame2: Frame = {
+      ...createFrame({ x: 0, y: 72, w: 96, h: 54 }),
+      gridRow: 4, gridCol: 0, gridW: 10, gridH: 3,
+      docOffset: 16, lineCount: 3,
+    };
+    const state = createEditorState({ prose, frames: [frame1, frame2] });
+    let s = moveCursorTo(state, { row: 7, col: 0 });
+    s = proseMoveUp(s);
+    const cursor = getCursor(s);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.row).toBe(0); // skipped lines 1-6 (two adjacent wireframes)
+  });
+
+  it("proseMoveDown at last prose line is no-op", () => {
+    const text = `Hello
+┌────┐
+│ Bx │
+└────┘
+World`;
+    const cw = 9.6, ch = 18;
+    let state = createEditorStateUnified(text, cw, ch);
+    state = moveCursorTo(state, { row: 4, col: 0 });
+    const before = getCursor(state);
+    state = proseMoveDown(state);
+    const after = getCursor(state);
+    expect(after!.row).toBe(before!.row);
+  });
+
+  it("proseMoveUp at first prose line is no-op", () => {
+    const text = `Hello
+┌────┐
+│ Bx │
+└────┘
+World`;
+    const cw = 9.6, ch = 18;
+    let state = createEditorStateUnified(text, cw, ch);
+    state = moveCursorTo(state, { row: 0, col: 0 });
+    state = proseMoveUp(state);
+    const cursor = getCursor(state);
+    expect(cursor!.row).toBe(0);
+  });
+
+  it("proseMoveDown preserves column clamped to next line length", () => {
+    // line 0: "Hello" (5 chars), line 4: "Hi" (2 chars) → col 5 → clamped to 2
+    const text = `Hello
+┌────┐
+│ Bx │
+└────┘
+Hi`;
+    const cw = 9.6, ch = 18;
+    let state = createEditorStateUnified(text, cw, ch);
+    state = moveCursorTo(state, { row: 0, col: 5 });
+    state = proseMoveDown(state);
+    const cursor = getCursor(state);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.row).toBe(4);
+    expect(cursor!.col).toBe(2); // "Hi" has 2 graphemes, col 5 clamped to 2
   });
 });

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -2209,3 +2209,73 @@ describe("add wireframe in unified mode", () => {
     expect(updated.doc.line(3).text).toBe("World");
   });
 });
+
+// ── Top-level frame gridRow must agree with docOffset ──────────────────────
+//
+// For top-level frames, gridRow is a CACHE of "what doc line does docOffset
+// land on". After any mutation, they MUST agree. The serializer reads
+// gridRow; the doc holds claimed lines via docOffset. Drift between them
+// produces output corruption.
+
+describe("top-level frame gridRow == lineAt(docOffset).number - 1", () => {
+  it("after drag-down past doc end, gridRow matches docOffset (clamped)", () => {
+    // Reproduces the e2e harness "drag: move box down" failure exactly.
+    const SIMPLE_BOX = "Prose above\n\n┌──────────────┐\n│              │\n│              │\n└──────────────┘\n\nProse below";
+    let state = createEditorStateUnified(SIMPLE_BOX, 9.6, 18);
+    const before = getFrames(state)[0];
+    state = state.update({
+      effects: moveFrameEffect.of({
+        id: before.id, dCol: 0, dRow: 5,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(state)[0];
+    const expectedRow = state.doc.lineAt(after.docOffset).number - 1;
+    expect(after.gridRow).toBe(expectedRow);
+  });
+
+  it("after drag-up, gridRow matches docOffset", () => {
+    const text = "A\nB\n\n\n┌──┐\n│Hi│\n└──┘\nZ";
+    let state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    state = state.update({
+      effects: moveFrameEffect.of({
+        id: before.id, dCol: 0, dRow: -2,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(state)[0];
+    const expectedRow = state.doc.lineAt(after.docOffset).number - 1;
+    expect(after.gridRow).toBe(expectedRow);
+  });
+
+  it("after prose Enter above frame, gridRow matches docOffset", () => {
+    const text = "Hi\n┌──┐\n│Bx│\n└──┘";
+    let state = createEditorStateUnified(text, 9.6, 18);
+    state = state.update({
+      changes: { from: 2, insert: "\n" },
+      userEvent: "input.type",
+    }).state;
+    const after = getFrames(state)[0];
+    const expectedRow = state.doc.lineAt(after.docOffset).number - 1;
+    expect(after.gridRow).toBe(expectedRow);
+  });
+
+  it("after resize-grow, gridRow matches docOffset", () => {
+    const text = "Hi\n┌──┐\n└──┘\nWorld";
+    let state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    state = state.update({
+      effects: resizeFrameEffect.of({
+        id: before.id, gridW: before.gridW, gridH: 4,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(state)[0];
+    const expectedRow = state.doc.lineAt(after.docOffset).number - 1;
+    expect(after.gridRow).toBe(expectedRow);
+  });
+});

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1354,3 +1354,94 @@ describe("createEditorStateUnified", () => {
     expect(getDoc(state)).toBe("AAAA\n\n\nBBBB");
   });
 });
+
+// ── Task 4: changeFilter protects claimed lines ────────────────────────────
+
+describe("changeFilter protects claimed lines", () => {
+  it("rejects user-event insertion into a claimed line", () => {
+    const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    const pos = frame.docOffset; // start of first claimed line
+    // Simulate user input via userEvent annotation
+    const updated = state.update({
+      changes: { from: pos, insert: "INJECTED" },
+      userEvent: "input.type",
+    }).state;
+    // Filter rejected → doc unchanged
+    expect(getDoc(updated)).toBe(getDoc(state));
+  });
+
+  it("rejects user-event deletion that touches a claimed range", () => {
+    const text = "Hello\n┌─┐\n└─┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    // Delete one char of the claimed range
+    const updated = state.update({
+      changes: { from: frame.docOffset, to: frame.docOffset + 1 },
+      userEvent: "delete.backward",
+    }).state;
+    expect(getDoc(updated)).toBe(getDoc(state));
+  });
+
+  it("allows user-event insertion into a prose line", () => {
+    const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const updated = state.update({
+      changes: { from: 0, insert: "X" },
+      userEvent: "input.type",
+    }).state;
+    expect(getDoc(updated).startsWith("XHello")).toBe(true);
+  });
+
+  it("allows non-user (programmatic) edits even on claimed ranges", () => {
+    // Programmatic move/resize/delete must be able to splice claimed lines.
+    // Transactions without a userEvent should bypass the filter.
+    const text = "Hello\n┌─┐\n└─┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    const updated = state.update({
+      changes: { from: frame.docOffset, to: frame.docOffset + 1 },
+      // no userEvent → programmatic
+    }).state;
+    // No filter applied → change went through
+    expect(getDoc(updated).length).toBe(getDoc(state).length - 1);
+  });
+
+  it("allows edits on prose-only docs (no frames)", () => {
+    const state = createEditorStateUnified("Just prose\nNo frames", 9.6, 18);
+    const updated = state.update({
+      changes: { from: 0, insert: "X" },
+      userEvent: "input.type",
+    }).state;
+    expect(getDoc(updated).startsWith("XJust prose")).toBe(true);
+  });
+
+  it("rejects multi-line replacement that spans a claimed range", () => {
+    const text = "Hello\n┌─┐\n└─┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    // Try to replace range [5..15] which includes the claimed lines
+    const updated = state.update({
+      changes: { from: 5, to: 9, insert: "XXX" },
+      userEvent: "input.type",
+    }).state;
+    expect(getDoc(updated)).toBe(getDoc(state));
+  });
+
+  it("rejects backspace at column 0 of line below wireframe (boundary)", () => {
+    // After unified doc: "Hello\n\n\n\nWorld" — frame claims lines 1-3.
+    // Cursor at start of "World" (line 4). Backspace would delete the \n at
+    // end of claimed line 3, intruding into the claimed range.
+    const text = "Hello\n┌─┐\n└─┘\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const doc = getDoc(state);
+    // Find position of "World" — it's after "Hello\n\n\n"
+    const worldStart = doc.indexOf("World");
+    const updated = state.update({
+      changes: { from: worldStart - 1, to: worldStart },
+      userEvent: "delete.backward",
+    }).state;
+    // Filter rejected → doc unchanged
+    expect(getDoc(updated)).toBe(doc);
+  });
+});

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1981,6 +1981,147 @@ Hi`;
   });
 });
 
+// ── Task 12: Drag wireframe — cut + insert claimed lines ─────────────────────
+
+describe("drag wireframe in unified mode", () => {
+  const cw = 9.6, ch = 18;
+
+  // Helper: build state and return the first (top-level) frame.
+  function makeState(text: string) {
+    const state = createEditorStateUnified(text, cw, ch);
+    const frame = getFrames(state)[0];
+    return { state, frame };
+  }
+
+  it("drag down by 3 relocates claimed lines, updates docOffset", () => {
+    // Frame at doc lines 2-4 (docOffset=6, lineCount=3), drag down past "World"
+    // Expected result: "Hello\nWorld\n\n\n\nEnd"
+    // Frame ends up at doc lines 3-5 (from=12)
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const { state, frame } = makeState(text);
+    expect(frame.lineCount).toBe(3);
+    expect(state.doc.lines).toBe(6);
+
+    const updated = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+
+    // Line count preserved
+    expect(updated.doc.lines).toBe(state.doc.lines);
+    // Doc matches expected layout
+    expect(getDoc(updated)).toBe("Hello\nWorld\n\n\n\nEnd");
+    // Frame docOffset points to start of first claimed line in new position
+    const updatedFrame = getFrames(updated)[0];
+    expect(updatedFrame.docOffset).toBe(12);
+    // Verify doc.lineAt(docOffset) is an empty line (still claimed)
+    expect(updated.doc.lineAt(updatedFrame.docOffset).text).toBe("");
+  });
+
+  it("drag up by 1 relocates claimed lines, updates docOffset", () => {
+    // Frame at doc lines 3-4 (docOffset=4, lineCount=2), drag up by 1
+    // Expected result: "A\n\n\nB\nC"
+    // Frame ends up at doc lines 2-3 (from=2)
+    const text = "A\nB\n┌─┐\n└─┘\nC";
+    const { state, frame } = makeState(text);
+    expect(frame.lineCount).toBe(2);
+    expect(state.doc.lines).toBe(5);
+
+    const updated = applyMoveFrame(state, frame.id, 0, -1, cw, ch);
+
+    expect(updated.doc.lines).toBe(state.doc.lines);
+    expect(getDoc(updated)).toBe("A\n\n\nB\nC");
+    const updatedFrame = getFrames(updated)[0];
+    expect(updatedFrame.docOffset).toBe(2);
+    expect(updated.doc.lineAt(updatedFrame.docOffset).text).toBe("");
+  });
+
+  it("drag down + undo restores pre-drag doc and docOffset", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const { state, frame } = makeState(text);
+    const preDragDoc = getDoc(state);
+    const preDragOffset = frame.docOffset;
+
+    const dragged = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    expect(getDoc(dragged)).not.toBe(preDragDoc);
+
+    const restored = editorUndo(dragged);
+    expect(getDoc(restored)).toBe(preDragDoc);
+    const restoredFrame = getFrames(restored)[0];
+    expect(restoredFrame.docOffset).toBe(preDragOffset);
+  });
+
+  it("drag up + undo restores pre-drag doc and docOffset", () => {
+    const text = "A\nB\n┌─┐\n└─┘\nC";
+    const { state, frame } = makeState(text);
+    const preDragDoc = getDoc(state);
+    const preDragOffset = frame.docOffset;
+
+    const dragged = applyMoveFrame(state, frame.id, 0, -1, cw, ch);
+    expect(getDoc(dragged)).not.toBe(preDragDoc);
+
+    const restored = editorUndo(dragged);
+    expect(getDoc(restored)).toBe(preDragDoc);
+    const restoredFrame = getFrames(restored)[0];
+    expect(restoredFrame.docOffset).toBe(preDragOffset);
+  });
+
+  it("undoDepth === 1 after a single drag", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const { state, frame } = makeState(text);
+    const dragged = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    // The drag (doc change + frame effect) should land as exactly one history entry.
+    expect(undoDepth(dragged)).toBe(1);
+  });
+
+  it("redo after undo restores post-drag state", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const { state, frame } = makeState(text);
+    const postDrag = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    const postDragDoc = getDoc(postDrag);
+
+    const undone = editorUndo(postDrag);
+    const redone = editorRedo(undone);
+    expect(getDoc(redone)).toBe(postDragDoc);
+    const redoneFrame = getFrames(redone)[0];
+    expect(redoneFrame.docOffset).toBe(12);
+  });
+
+  it("drag then prose-edit then undo twice — each undo is independent", () => {
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const { state, frame } = makeState(text);
+    const preDragDoc = getDoc(state);
+
+    // Step 1: drag
+    const afterDrag = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    const afterDragDoc = getDoc(afterDrag);
+
+    // Step 2: prose edit — insert "X" at start of "Hello"
+    const afterEdit = proseInsert(afterDrag, { row: 0, col: 0 }, "X");
+    const afterEditDoc = getDoc(afterEdit);
+    expect(afterEditDoc).not.toBe(afterDragDoc);
+
+    // Undo prose edit → back to post-drag state
+    const undo1 = editorUndo(afterEdit);
+    expect(getDoc(undo1)).toBe(afterDragDoc);
+
+    // Undo drag → back to pre-drag state
+    const undo2 = editorUndo(undo1);
+    expect(getDoc(undo2)).toBe(preDragDoc);
+  });
+
+  it("docOffset after undo equals pre-drag snapshot exactly", () => {
+    // Verify restoreFramesEffect overrides any mapPos result during undo.
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const { state, frame } = makeState(text);
+    const snapshotOffset = frame.docOffset; // 6
+
+    const dragged = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    const undone = editorUndo(dragged);
+
+    const undoneFrame = getFrames(undone)[0];
+    // Must match the exact snapshot — restoreFramesEffect overrides mapPos.
+    expect(undoneFrame.docOffset).toBe(snapshotOffset);
+  });
+});
+
 // ── Task 13: add wireframe in unified mode ────────────────────────────────────
 
 describe("add wireframe in unified mode", () => {

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1,11 +1,12 @@
 // src/editorState.test.ts
 // Tests for editorState.ts — Phase 3 plan verification.
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Transaction } from "@codemirror/state";
 import {
   createEditorState,
   createEditorStateFromText,
+  createEditorStateUnified,
   getDoc,
   getFrames,
   getCursor,
@@ -1049,7 +1050,7 @@ describe("applyClearDirty (Phase 2)", () => {
   it("resets dirty flag on all frames", () => {
     const f = createFrame({ x: 0, y: 0, w: 50, h: 50 });
     let state = createEditorState({ prose: "", frames: [f], proseSegmentMap: [] });
-    state = applyMoveFrame(state, f.id, 10, 10);
+    state = applyMoveFrame(state, f.id, 10, 10, 9.6, 18.4);
     expect(getFrames(state)[0].dirty).toBe(true);
     state = applyClearDirty(state);
     expect(getFrames(state)[0].dirty).toBe(false);
@@ -1062,7 +1063,7 @@ describe("applyClearDirty (Phase 2)", () => {
       children: [child],
     };
     let state = createEditorState({ prose: "", frames: [container], proseSegmentMap: [] });
-    state = applyMoveFrame(state, child.id, 5, 5);
+    state = applyMoveFrame(state, child.id, 5, 5, 9.6, 18.4);
     expect(getFrames(state)[0].dirty).toBe(true);
     expect(getFrames(state)[0].children[0].dirty).toBe(true);
     state = applyClearDirty(state);
@@ -1176,11 +1177,13 @@ describe("delete cascade", () => {
       id: "child1", x: 0, y: 0, w: 100, h: 50,
       z: 0, children: [], content: { type: "rect", cells: new Map(), style: { tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│" } },
       clip: false, dirty: false, gridRow: 0, gridCol: 0, gridW: 0, gridH: 0,
+      docOffset: 0, lineCount: 0,
     };
     const parent: Frame = {
       id: "parent1", x: 0, y: 0, w: 200, h: 100,
       z: 0, children: [child], content: null,
       clip: true, dirty: false, gridRow: 0, gridCol: 0, gridW: 0, gridH: 0,
+      docOffset: 0, lineCount: 0,
     };
     const state = createEditorState({
       prose: "", frames: [parent], proseSegmentMap: [],
@@ -1194,15 +1197,18 @@ describe("delete cascade", () => {
       id: "c1", x: 0, y: 0, w: 50, h: 50, z: 0, children: [],
       content: { type: "rect", cells: new Map(), style: { tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│" } },
       clip: false, dirty: false, gridRow: 0, gridCol: 0, gridW: 0, gridH: 0,
+      docOffset: 0, lineCount: 0,
     };
     const child2: Frame = {
       id: "c2", x: 60, y: 0, w: 50, h: 50, z: 0, children: [],
       content: { type: "rect", cells: new Map(), style: { tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│" } },
       clip: false, dirty: false, gridRow: 0, gridCol: 0, gridW: 0, gridH: 0,
+      docOffset: 0, lineCount: 0,
     };
     const parent: Frame = {
       id: "p1", x: 0, y: 0, w: 200, h: 100, z: 0,
       children: [child1, child2], content: null, clip: true, dirty: false, gridRow: 0, gridCol: 0, gridW: 0, gridH: 0,
+      docOffset: 0, lineCount: 0,
     };
     const state = createEditorState({ prose: "", frames: [parent], proseSegmentMap: [] });
     const updated = applyDeleteFrame(state, "c1");
@@ -1224,5 +1230,127 @@ describe("originalProseSegments refresh", () => {
     const newSegs = [{ row: 0, col: 0, text: "Updated" }];
     const updated = applySetOriginalProseSegments(state, newSegs);
     expect(getOriginalProseSegments(updated)).toEqual(newSegs);
+  });
+});
+
+// ── Task 3: createEditorStateUnified ────────────────────────────────────────
+
+describe("createEditorStateUnified", () => {
+  beforeAll(() => {
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreateElement(tag);
+      if (tag === "canvas") {
+        (el as HTMLCanvasElement).getContext = (() => ({
+          font: "", fillStyle: "", textBaseline: "", fillText: () => {},
+          measureText: (text: string) => ({
+            width: text.length * 9.6,
+            actualBoundingBoxAscent: 12,
+            actualBoundingBoxDescent: 4,
+          }),
+        })) as unknown as HTMLCanvasElement["getContext"];
+      }
+      return el;
+    });
+  });
+
+  it("CM doc preserves line count with empty strings for wireframe lines", () => {
+    // Plan amendment: claimed lines are "" (empty), not " " — preparedCache.ts:12
+    // maps non-empty strings to non-null PreparedTextWithSegments, generating
+    // spurious PositionedLines. Empty strings hit the null fast-path.
+    const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const doc = getDoc(state);
+    const lines = doc.split("\n");
+    expect(lines.length).toBe(7);
+    expect(lines[0]).toBe("Hello");
+    expect(lines[1]).toBe("");
+    expect(lines[5]).toBe("");
+    expect(lines[6]).toBe("Goodbye");
+    expect(lines[2]).toBe(""); // claimed
+    expect(lines[3]).toBe(""); // claimed
+    expect(lines[4]).toBe(""); // claimed
+  });
+
+  it("frames have correct docOffset pointing into unified doc", () => {
+    const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frames = getFrames(state);
+    expect(frames.length).toBeGreaterThanOrEqual(1);
+    const frame = frames[0];
+    expect(frame.lineCount).toBe(3);
+    // Unified doc lines: "Hello"(5) + \n + ""(0) + \n = 7 → frame starts at 7
+    expect(frame.docOffset).toBe(7);
+  });
+
+  it("pure prose passes through unchanged", () => {
+    const text = "Just some prose\nNo wireframes";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    expect(getDoc(state)).toBe(text);
+    expect(getFrames(state)).toHaveLength(0);
+  });
+
+  it("wireframe at start of file has docOffset 0", () => {
+    const text = "┌──┐\n│Hi│\n└──┘\nbye";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    expect(frame.docOffset).toBe(0);
+    expect(frame.lineCount).toBe(3);
+    const lines = getDoc(state).split("\n");
+    expect(lines[0]).toBe("");
+    expect(lines[1]).toBe("");
+    expect(lines[2]).toBe("");
+    expect(lines[3]).toBe("bye");
+  });
+
+  it("wireframe at end of file with no trailing newline", () => {
+    const text = "Hello\n┌──┐\n│Hi│\n└──┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    expect(frame.lineCount).toBe(3);
+    const lines = getDoc(state).split("\n");
+    expect(lines.length).toBe(4);
+    expect(lines[0]).toBe("Hello");
+    expect(lines[1]).toBe("");
+    expect(lines[2]).toBe("");
+    expect(lines[3]).toBe("");
+    // docOffset = "Hello\n" = 6
+    expect(frame.docOffset).toBe(6);
+  });
+
+  it("two wireframes separated by enough prose remain separate top-level frames", () => {
+    // groupIntoContainers merges shapes within charHeight pixels gap.
+    // Need a gap of (charHeight + 1) pixels — translate to cellHeight=18 → > 1 row.
+    // Use multiple blank rows + prose between to guarantee separation.
+    const text = "┌──┐\n│A │\n└──┘\n\n\n\n\n\nbetween\n\n\n\n\n\n┌──┐\n│B │\n└──┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frames = getFrames(state);
+    expect(frames.length).toBe(2);
+    const [first, second] = frames;
+    expect(first.lineCount).toBe(3);
+    expect(second.lineCount).toBe(3);
+    expect(first.docOffset).toBe(0);
+    // Verify second is positioned below the prose
+    expect(second.gridRow).toBeGreaterThan(first.gridRow + first.gridH);
+  });
+
+  it("preserves docOffset 0 for first claimed line at file start", () => {
+    const text = "┌─┐\n└─┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    expect(frame.docOffset).toBe(0);
+    expect(frame.lineCount).toBe(2);
+  });
+
+  it("docOffset accounts for empty-line shrinkage in unified doc", () => {
+    // Source lines: "AAAA" (4) "┌─┐" (3) "└─┘" (3) "BBBB" (4)
+    // Unified lines: "AAAA" (4) "" (0) "" (0) "BBBB" (4)
+    // Frame docOffset = "AAAA\n" = 5
+    const text = "AAAA\n┌─┐\n└─┘\nBBBB";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    expect(frame.docOffset).toBe(5);
+    expect(frame.lineCount).toBe(2);
+    expect(getDoc(state)).toBe("AAAA\n\n\nBBBB");
   });
 });

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1580,3 +1580,66 @@ describe("docOffset remapping through edits", () => {
     expect(updatedFrames[1].docOffset).toBe(before2 + 1);
   });
 });
+
+// ── Task 9: Enter/Backspace above wireframe ────────────────────────────────
+
+describe("Enter/Backspace above wireframe (should work via mapPos)", () => {
+  it("Enter at end of prose line above wireframe shifts frame down by 1", () => {
+    // Unified doc: "Hi\n\n\n\n" — frame at docOffset=3 (lines 1-3 claimed).
+    const text = "Hi\n┌────┐\n│ Bx │\n└────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    // Simulate "Enter at end of 'Hi'" — insert \n at offset 2
+    const updated = state.update({
+      changes: { from: 2, insert: "\n" },
+      userEvent: "input.type",
+    }).state;
+    const after = getFrames(updated)[0];
+    expect(after.docOffset).toBe(before.docOffset + 1);
+    expect(after.lineCount).toBe(before.lineCount); // claim size unchanged
+    expect(updated.doc.lines).toBe(state.doc.lines + 1);
+  });
+
+  it("Backspace on blank prose line above wireframe shifts frame up by 1", () => {
+    const text = "Hi\n\n┌────┐\n│ Bx │\n└────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    // Delete the \n at position 2 (the blank line above frame)
+    const updated = state.update({
+      changes: { from: 2, to: 3 },
+      userEvent: "delete.backward",
+    }).state;
+    const after = getFrames(updated)[0];
+    expect(after.docOffset).toBe(before.docOffset - 1);
+    expect(after.lineCount).toBe(before.lineCount);
+  });
+
+  it("typing a character in prose line above wireframe shifts frame by +1", () => {
+    const text = "Hi\n┌────┐\n│ Bx │\n└────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    // Insert "X" at end of "Hi" (offset 2)
+    const updated = state.update({
+      changes: { from: 2, insert: "X" },
+      userEvent: "input.type",
+    }).state;
+    const after = getFrames(updated)[0];
+    expect(after.docOffset).toBe(before.docOffset + 1);
+    expect(after.lineCount).toBe(before.lineCount);
+  });
+
+  it("Enter above wireframe is undoable — frame returns to original position", () => {
+    const text = "Hi\n┌────┐\n│ Bx │\n└────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0];
+    let s = state.update({
+      changes: { from: 2, insert: "\n" },
+      userEvent: "input.type",
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    expect(getFrames(s)[0].docOffset).toBe(before.docOffset + 1);
+    s = editorUndo(s);
+    expect(getFrames(s)[0].docOffset).toBe(before.docOffset);
+    expect(getDoc(s)).toBe(getDoc(state));
+  });
+});

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1358,18 +1358,35 @@ describe("createEditorStateUnified", () => {
 // ── Task 4: changeFilter protects claimed lines ────────────────────────────
 
 describe("changeFilter protects claimed lines", () => {
-  it("rejects user-event insertion into a claimed line", () => {
+  it("rejects user-event insertion INSIDE a claimed line (not at boundary)", () => {
+    // Insertion AT the start of a claimed range is allowed (treated as
+    // before-the-claim — Enter-above-wireframe). To exercise the filter
+    // we insert ONE char past the start, where the position is mid-claim.
     const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
     const state = createEditorStateUnified(text, 9.6, 18);
     const frame = getFrames(state)[0];
-    const pos = frame.docOffset; // start of first claimed line
-    // Simulate user input via userEvent annotation
+    const pos = frame.docOffset + 1; // mid-claim
     const updated = state.update({
       changes: { from: pos, insert: "INJECTED" },
       userEvent: "input.type",
     }).state;
-    // Filter rejected → doc unchanged
     expect(getDoc(updated)).toBe(getDoc(state));
+  });
+
+  it("allows user-event insertion AT claimed-range start (Enter-above-wireframe)", () => {
+    // Pure insertion at docOffset is "before the claim". With mapPos
+    // associativity=1, the frame's docOffset shifts forward by the inserted
+    // length and the claim still owns the original lines.
+    const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frame = getFrames(state)[0];
+    const before = frame.docOffset;
+    const updated = state.update({
+      changes: { from: before, insert: "X" },
+      userEvent: "input.type",
+    }).state;
+    expect(getDoc(updated).length).toBe(getDoc(state).length + 1);
+    expect(getFrames(updated)[0].docOffset).toBe(before + 1);
   });
 
   it("rejects user-event deletion that touches a claimed range", () => {
@@ -1443,5 +1460,123 @@ describe("changeFilter protects claimed lines", () => {
     }).state;
     // Filter rejected → doc unchanged
     expect(getDoc(updated)).toBe(doc);
+  });
+});
+
+// ── Task 5: docOffset remapping through CM edits ───────────────────────────
+
+describe("docOffset remapping through edits", () => {
+  it("inserting a char before frame shifts docOffset forward", () => {
+    const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0].docOffset;
+    // Insert a single char at position 0 (before "Hello")
+    const updated = state.update({
+      changes: { from: 0, insert: "X" },
+      userEvent: "input.type",
+    }).state;
+    const after = getFrames(updated)[0].docOffset;
+    expect(after).toBe(before + 1);
+  });
+
+  it("inserting a newline before frame shifts docOffset by +1", () => {
+    const text = "Hello\n\n┌──────┐\n│ Box  │\n└──────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0].docOffset;
+    const updated = state.update({
+      changes: { from: 0, insert: "\n" },
+      userEvent: "input.type",
+    }).state;
+    const after = getFrames(updated)[0].docOffset;
+    expect(after).toBe(before + 1);
+  });
+
+  it("deleting a char before frame shifts docOffset backward", () => {
+    const text = "AAAA\n\n┌──────┐\n│ Box  │\n└──────┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0].docOffset;
+    const updated = state.update({
+      changes: { from: 0, to: 1 }, // delete first "A"
+      userEvent: "delete.forward",
+    }).state;
+    const after = getFrames(updated)[0].docOffset;
+    expect(after).toBe(before - 1);
+  });
+
+  it("inserting at exact frame docOffset pushes frame forward (associativity=1)", () => {
+    // The Gemini correction: mapPos(offset, 1) so frame follows insertions
+    // landing AT its docOffset. This is what "Enter above wireframe" does.
+    const text = "Hello\n\n┌──┐\n└──┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0].docOffset;
+    // Insert at position == docOffset
+    const updated = state.update({
+      changes: { from: before, insert: "X" },
+      userEvent: "input.type",
+    }).state;
+    const after = getFrames(updated)[0].docOffset;
+    // Frame moved forward — the inserted char is BEFORE the claimed range.
+    expect(after).toBe(before + 1);
+  });
+
+  it("paste of multi-line content before frame shifts by total length", () => {
+    const text = "A\n┌──┐\n└──┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0].docOffset;
+    const insert = "X\nY\nZ"; // 5 chars including 2 newlines
+    const updated = state.update({
+      changes: { from: 0, insert },
+      userEvent: "input.paste",
+    }).state;
+    const after = getFrames(updated)[0].docOffset;
+    expect(after).toBe(before + insert.length);
+  });
+
+  it("edit AFTER frame does not change docOffset", () => {
+    const text = "A\n┌──┐\n└──┘\nXXXX";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const before = getFrames(state)[0].docOffset;
+    const doc = getDoc(state);
+    // Insert at end of doc (after frame's claimed range)
+    const updated = state.update({
+      changes: { from: doc.length, insert: "Q" },
+      userEvent: "input.type",
+    }).state;
+    const after = getFrames(updated)[0].docOffset;
+    expect(after).toBe(before);
+  });
+
+  it("two frames: edit before frame1 shifts both", () => {
+    const text = "A\n┌──┐\n└──┘\n\n\n\n\nbetween\n\n\n\n\n\n┌──┐\n└──┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frames = getFrames(state);
+    expect(frames.length).toBe(2);
+    const before1 = frames[0].docOffset;
+    const before2 = frames[1].docOffset;
+    const updated = state.update({
+      changes: { from: 0, insert: "Z" },
+      userEvent: "input.type",
+    }).state;
+    const updatedFrames = getFrames(updated);
+    expect(updatedFrames[0].docOffset).toBe(before1 + 1);
+    expect(updatedFrames[1].docOffset).toBe(before2 + 1);
+  });
+
+  it("two frames: edit between them shifts only the second", () => {
+    const text = "A\n┌──┐\n└──┘\n\n\n\n\nM\n\n\n\n\n\n┌──┐\n└──┘";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const frames = getFrames(state);
+    expect(frames.length).toBe(2);
+    const before1 = frames[0].docOffset;
+    const before2 = frames[1].docOffset;
+    const doc = getDoc(state);
+    const mPos = doc.indexOf("M");
+    const updated = state.update({
+      changes: { from: mPos, insert: "Z" },
+      userEvent: "input.type",
+    }).state;
+    const updatedFrames = getFrames(updated);
+    expect(updatedFrames[0].docOffset).toBe(before1); // unchanged
+    expect(updatedFrames[1].docOffset).toBe(before2 + 1);
   });
 });

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1993,105 +1993,118 @@ describe("drag wireframe in unified mode", () => {
     return { state, frame };
   }
 
-  it("drag down by 3 relocates claimed lines, updates docOffset", () => {
-    // Frame at doc lines 2-4 (docOffset=6, lineCount=3), drag down past "World"
-    // Expected result: "Hello\nWorld\n\n\n\nEnd"
-    // Frame ends up at doc lines 3-5 (from=12)
-    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+  // NOTE: drag-vertical is now a NEWLINE ROTATION model — it moves the frame
+  // by absorbing adjacent empty (claim-eligible) lines, not by pushing past
+  // prose. dRow is clamped to the count of consecutive empty lines on the
+  // appropriate side.
+
+  it("drag down by 1 into adjacent empty line moves the claim", () => {
+    // Frame at rows 1-3 (lines 2-4 1-indexed). One empty line below at L4.
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\n\nWorld";
     const { state, frame } = makeState(text);
     expect(frame.lineCount).toBe(3);
-    expect(state.doc.lines).toBe(6);
-
-    const updated = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
-
-    // Line count preserved
+    const updated = applyMoveFrame(state, frame.id, 0, 1, cw, ch);
+    // Doc length preserved; frame moved down by 1.
     expect(updated.doc.lines).toBe(state.doc.lines);
-    // Doc matches expected layout
-    expect(getDoc(updated)).toBe("Hello\nWorld\n\n\n\nEnd");
-    // Frame docOffset points to start of first claimed line in new position
     const updatedFrame = getFrames(updated)[0];
-    expect(updatedFrame.docOffset).toBe(12);
-    // Verify doc.lineAt(docOffset) is an empty line (still claimed)
-    expect(updated.doc.lineAt(updatedFrame.docOffset).text).toBe("");
+    expect(updatedFrame.gridRow).toBe(frame.gridRow + 1);
+    expect(updated.doc.lineAt(updatedFrame.docOffset).number - 1).toBe(updatedFrame.gridRow);
   });
 
-  it("drag up by 1 relocates claimed lines, updates docOffset", () => {
-    // Frame at doc lines 3-4 (docOffset=4, lineCount=2), drag up by 1
-    // Expected result: "A\n\n\nB\nC"
-    // Frame ends up at doc lines 2-3 (from=2)
-    const text = "A\nB\n┌─┐\n└─┘\nC";
-    const { state, frame } = makeState(text);
-    expect(frame.lineCount).toBe(2);
-    expect(state.doc.lines).toBe(5);
-
-    const updated = applyMoveFrame(state, frame.id, 0, -1, cw, ch);
-
-    expect(updated.doc.lines).toBe(state.doc.lines);
-    expect(getDoc(updated)).toBe("A\n\n\nB\nC");
-    const updatedFrame = getFrames(updated)[0];
-    expect(updatedFrame.docOffset).toBe(2);
-    expect(updated.doc.lineAt(updatedFrame.docOffset).text).toBe("");
-  });
-
-  it("drag down + undo restores pre-drag doc and docOffset", () => {
+  it("drag down past prose is clamped to no-op (no empty lines to absorb)", () => {
+    // Frame at rows 1-3, no empty lines between frame and "World".
     const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const { state, frame } = makeState(text);
+    const preDoc = getDoc(state);
+    const updated = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    // No empty lines below → no-op. Doc unchanged.
+    expect(getDoc(updated)).toBe(preDoc);
+    const updatedFrame = getFrames(updated)[0];
+    expect(updatedFrame.gridRow).toBe(frame.gridRow);
+  });
+
+  it("drag up by 1 into adjacent empty line", () => {
+    const text = "A\n\nB\n┌─┐\n└─┘\nC";
+    const { state, frame } = makeState(text);
+    // No empty line above frame — clamp to no-op.
+    const preDoc = getDoc(state);
+    const updated = applyMoveFrame(state, frame.id, 0, -1, cw, ch);
+    expect(getDoc(updated)).toBe(preDoc);
+    expect(getFrames(updated)[0].gridRow).toBe(frame.gridRow);
+  });
+
+  it("drag up by 1 with empty line above", () => {
+    // Frame at L3-L4 (1-indexed) with empty L2 above.
+    const text = "A\n\n┌─┐\n└─┘\nC";
+    const { state, frame } = makeState(text);
+    const updated = applyMoveFrame(state, frame.id, 0, -1, cw, ch);
+    expect(updated.doc.lines).toBe(state.doc.lines);
+    const updatedFrame = getFrames(updated)[0];
+    expect(updatedFrame.gridRow).toBe(frame.gridRow - 1);
+  });
+
+  it("drag down + undo restores pre-drag docOffset", () => {
+    // Doc length is invariant under newline-rotation drag, but docOffset
+    // does change. Undo must restore docOffset to its pre-drag value.
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\n\nWorld";
     const { state, frame } = makeState(text);
     const preDragDoc = getDoc(state);
     const preDragOffset = frame.docOffset;
 
-    const dragged = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
-    expect(getDoc(dragged)).not.toBe(preDragDoc);
+    const dragged = applyMoveFrame(state, frame.id, 0, 1, cw, ch);
+    expect(getFrames(dragged)[0].docOffset).not.toBe(preDragOffset);
 
     const restored = editorUndo(dragged);
     expect(getDoc(restored)).toBe(preDragDoc);
-    const restoredFrame = getFrames(restored)[0];
-    expect(restoredFrame.docOffset).toBe(preDragOffset);
+    expect(getFrames(restored)[0].docOffset).toBe(preDragOffset);
   });
 
-  it("drag up + undo restores pre-drag doc and docOffset", () => {
-    const text = "A\nB\n┌─┐\n└─┘\nC";
+  it("drag up + undo restores pre-drag docOffset", () => {
+    const text = "A\n\n┌─┐\n└─┘\nC";
     const { state, frame } = makeState(text);
     const preDragDoc = getDoc(state);
     const preDragOffset = frame.docOffset;
 
     const dragged = applyMoveFrame(state, frame.id, 0, -1, cw, ch);
-    expect(getDoc(dragged)).not.toBe(preDragDoc);
+    expect(getFrames(dragged)[0].docOffset).not.toBe(preDragOffset);
 
     const restored = editorUndo(dragged);
     expect(getDoc(restored)).toBe(preDragDoc);
-    const restoredFrame = getFrames(restored)[0];
-    expect(restoredFrame.docOffset).toBe(preDragOffset);
+    expect(getFrames(restored)[0].docOffset).toBe(preDragOffset);
   });
 
   it("undoDepth === 1 after a single drag", () => {
-    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\n\nWorld";
     const { state, frame } = makeState(text);
-    const dragged = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    const dragged = applyMoveFrame(state, frame.id, 0, 1, cw, ch);
     // The drag (doc change + frame effect) should land as exactly one history entry.
     expect(undoDepth(dragged)).toBe(1);
   });
 
   it("redo after undo restores post-drag state", () => {
-    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\n\nWorld";
     const { state, frame } = makeState(text);
-    const postDrag = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    const postDrag = applyMoveFrame(state, frame.id, 0, 1, cw, ch);
     const postDragDoc = getDoc(postDrag);
+    const postDragOffset = getFrames(postDrag)[0].docOffset;
 
     const undone = editorUndo(postDrag);
     const redone = editorRedo(undone);
     expect(getDoc(redone)).toBe(postDragDoc);
     const redoneFrame = getFrames(redone)[0];
-    expect(redoneFrame.docOffset).toBe(12);
+    expect(redoneFrame.docOffset).toBe(postDragOffset);
   });
 
   it("drag then prose-edit then undo twice — each undo is independent", () => {
-    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\n\nWorld";
     const { state, frame } = makeState(text);
     const preDragDoc = getDoc(state);
 
+    const preDragOffset = frame.docOffset;
     // Step 1: drag
-    const afterDrag = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    const afterDrag = applyMoveFrame(state, frame.id, 0, 1, cw, ch);
     const afterDragDoc = getDoc(afterDrag);
+    expect(getFrames(afterDrag)[0].docOffset).not.toBe(preDragOffset);
 
     // Step 2: prose edit — insert "X" at start of "Hello"
     const afterEdit = proseInsert(afterDrag, { row: 0, col: 0 }, "X");
@@ -2109,15 +2122,14 @@ describe("drag wireframe in unified mode", () => {
 
   it("docOffset after undo equals pre-drag snapshot exactly", () => {
     // Verify restoreFramesEffect overrides any mapPos result during undo.
-    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\nWorld\nEnd";
+    const text = "Hello\n┌────┐\n│ Bx │\n└────┘\n\nWorld";
     const { state, frame } = makeState(text);
-    const snapshotOffset = frame.docOffset; // 6
+    const snapshotOffset = frame.docOffset;
 
-    const dragged = applyMoveFrame(state, frame.id, 0, 3, cw, ch);
+    const dragged = applyMoveFrame(state, frame.id, 0, 1, cw, ch);
     const undone = editorUndo(dragged);
 
     const undoneFrame = getFrames(undone)[0];
-    // Must match the exact snapshot — restoreFramesEffect overrides mapPos.
     expect(undoneFrame.docOffset).toBe(snapshotOffset);
   });
 });
@@ -2277,5 +2289,87 @@ describe("top-level frame gridRow == lineAt(docOffset).number - 1", () => {
     const after = getFrames(state)[0];
     const expectedRow = state.doc.lineAt(after.docOffset).number - 1;
     expect(after.gridRow).toBe(expectedRow);
+  });
+
+  it("drag past doc end clamps lineCount so frame doesn't claim prose lines", () => {
+    // Reproduces e2e harness "prose order preserved when dragging wireframe down".
+    // 5-line frame (gridH=5: top + 3 inner + bottom) starts at row 2.
+    // Drag down 8 rows → would land at row 10 in a doc that only has 8 lines.
+    // Without proper clamp, the frame's claimed range overlaps "Prose B".
+    const fixture = "Prose A first\n\n┌──────────────┐\n│              │\n│   Wireframe  │\n│              │\n└──────────────┘\n\nProse B second";
+    let state = createEditorStateUnified(fixture, 9.6, 18);
+    const before = getFrames(state)[0];
+    state = state.update({
+      effects: moveFrameEffect.of({
+        id: before.id, dCol: 0, dRow: 8,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const after = getFrames(state)[0];
+    // Compute the line that contains "Prose B second" in the post-drag doc.
+    const doc = getDoc(state);
+    const proseBLine = doc.split("\n").findIndex(l => l.includes("Prose B"));
+    expect(proseBLine).toBeGreaterThanOrEqual(0);
+    // The frame must NOT claim the "Prose B" line.
+    const claimedEnd = after.gridRow + after.lineCount - 1;
+    expect(after.gridRow).toBeLessThan(proseBLine);
+    expect(claimedEnd).toBeLessThan(proseBLine);
+  });
+
+  it("drag past doc end: serializeUnified output preserves Prose B intact", async () => {
+    // The hard one: after the drag-clamp, does serializeUnified produce
+    // output containing literal "Prose B second"?
+    const { serializeUnified } = await import("./serializeUnified");
+    const fixture = "Prose A first\n\n┌──────────────┐\n│              │\n│   Wireframe  │\n│              │\n└──────────────┘\n\nProse B second";
+    let state = createEditorStateUnified(fixture, 9.6, 18);
+    const before = getFrames(state)[0];
+    state = state.update({
+      effects: moveFrameEffect.of({
+        id: before.id, dCol: 0, dRow: 8,
+        charWidth: 9.6, charHeight: 18,
+      }),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    const out = serializeUnified(getDoc(state), getFrames(state));
+    expect(out).toContain("Prose A first");
+    expect(out).toContain("Prose B second");
+    expect(out).toContain("Wireframe");
+  });
+
+  it("incremental drag (10 small dRow=1 steps) preserves Prose B", async () => {
+    const { serializeUnified } = await import("./serializeUnified");
+    const fixture = "Prose A first\n\n┌──────────────┐\n│              │\n│   Wireframe  │\n│              │\n└──────────────┘\n\nProse B second";
+    let state = createEditorStateUnified(fixture, 9.6, 18);
+    const id = getFrames(state)[0].id;
+    const dump = (label: string) => {
+      const f = getFrames(state)[0];
+      const doc = getDoc(state);
+      const lines = doc.split("\n");
+      // eslint-disable-next-line no-console
+      console.log(`\n${label}: gridRow=${f.gridRow} docOffset=${f.docOffset} lineCount=${f.lineCount} doc.length=${doc.length} doc=${JSON.stringify(doc)}`);
+      for (let li = 0; li < lines.length; li++) {
+        const claimed = li >= f.gridRow && li < f.gridRow + f.lineCount;
+        // eslint-disable-next-line no-console
+        console.log(`  L${li}: ${claimed ? "[CLAIM]" : "[prose]"} ${JSON.stringify(lines[li])}`);
+      }
+    };
+    dump("initial");
+    for (let i = 0; i < 5; i++) {
+      state = state.update({
+        effects: moveFrameEffect.of({
+          id, dCol: 0, dRow: 1,
+          charWidth: 9.6, charHeight: 18,
+        }),
+        annotations: Transaction.addToHistory.of(i === 0),
+      }).state;
+      dump(`after step ${i}`);
+    }
+    const out = serializeUnified(getDoc(state), getFrames(state));
+    // eslint-disable-next-line no-console
+    console.log("=== serialized ===\n" + out);
+    expect(out).toContain("Prose A first");
+    expect(out).toContain("Prose B second");
+    expect(out).toContain("Wireframe");
   });
 });

--- a/src/editorState.test.ts
+++ b/src/editorState.test.ts
@@ -1980,3 +1980,91 @@ Hi`;
     expect(cursor!.col).toBe(2); // "Hi" has 2 graphemes, col 5 clamped to 2
   });
 });
+
+// ── Task 13: add wireframe in unified mode ────────────────────────────────────
+
+describe("add wireframe in unified mode", () => {
+  const STYLE = { tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│" };
+
+  it("adding a frame with lineCount=3 inserts 3 blank lines at docOffset", () => {
+    const text = "Hello\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    // "Hello\n" = 6 chars; docOffset=6 points to start of "World"
+    const newFrame = createRectFrame({ gridW: 6, gridH: 3, style: STYLE, charWidth: 9.6, charHeight: 18 });
+    newFrame.docOffset = 6;
+    newFrame.lineCount = 3;
+    newFrame.gridRow = 1;
+    const updated = applyAddFrame(state, newFrame);
+    // Inserting "\n\n\n" at offset 6: "Hello\n" + "\n\n\n" + "World" = "Hello\n\n\n\nWorld"
+    // Lines (1-indexed): 1="Hello", 2="", 3="", 4="", 5="World"
+    expect(updated.doc.lines).toBe(state.doc.lines + 3);
+    expect(updated.doc.line(2).text).toBe("");
+    expect(updated.doc.line(3).text).toBe("");
+    expect(updated.doc.line(4).text).toBe("");
+    expect(updated.doc.line(5).text).toBe("World");
+  });
+
+  it("adding a frame at end of doc inserts blank lines after existing prose", () => {
+    const text = "Hello";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    // doc.length = 5; docOffset=5 = end of doc
+    const newFrame = createRectFrame({ gridW: 6, gridH: 3, style: STYLE, charWidth: 9.6, charHeight: 18 });
+    newFrame.docOffset = 5;
+    newFrame.lineCount = 3;
+    newFrame.gridRow = 1;
+    const updated = applyAddFrame(state, newFrame);
+    // Inserting "\n\n\n" at offset 5: "Hello" + "\n\n\n" = "Hello\n\n\n"
+    // Lines: 1="Hello", 2="", 3="", 4=""
+    expect(updated.doc.lines).toBe(4);
+    expect(updated.doc.line(1).text).toBe("Hello");
+    expect(updated.doc.line(2).text).toBe("");
+    expect(updated.doc.line(3).text).toBe("");
+    expect(updated.doc.line(4).text).toBe("");
+  });
+
+  it("adding a child frame (lineCount=0) does NOT touch the doc", () => {
+    const text = "Hello\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const docBefore = getDoc(state);
+    const childFrame = createRectFrame({ gridW: 4, gridH: 2, style: STYLE, charWidth: 9.6, charHeight: 18 });
+    // lineCount=0 by default from createRectFrame — no claimed lines
+    expect(childFrame.lineCount).toBe(0);
+    const updated = applyAddFrame(state, childFrame);
+    expect(getDoc(updated)).toBe(docBefore);
+    expect(updated.doc.lines).toBe(state.doc.lines);
+  });
+
+  it("add frame is undoable — doc and frames restored", () => {
+    const text = "Hello\nWorld";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    const origDoc = getDoc(state);
+    const origFrameCount = getFrames(state).length;
+    const newFrame = createRectFrame({ gridW: 6, gridH: 3, style: STYLE, charWidth: 9.6, charHeight: 18 });
+    newFrame.docOffset = 6;
+    newFrame.lineCount = 3;
+    newFrame.gridRow = 1;
+    const afterAdd = applyAddFrame(state, newFrame);
+    expect(afterAdd.doc.lines).toBe(state.doc.lines + 3);
+    expect(getFrames(afterAdd).length).toBe(origFrameCount + 1);
+    const afterUndo = editorUndo(afterAdd);
+    expect(getDoc(afterUndo)).toBe(origDoc);
+    expect(getFrames(afterUndo).length).toBe(origFrameCount);
+  });
+
+  it("adding a frame at file start inserts blank lines before existing prose", () => {
+    const text = "World";
+    const state = createEditorStateUnified(text, 9.6, 18);
+    // docOffset=0 = start of doc
+    const newFrame = createRectFrame({ gridW: 6, gridH: 2, style: STYLE, charWidth: 9.6, charHeight: 18 });
+    newFrame.docOffset = 0;
+    newFrame.lineCount = 2;
+    newFrame.gridRow = 0;
+    const updated = applyAddFrame(state, newFrame);
+    // Inserting "\n\n" at offset 0: "\n\n" + "World" = "\n\nWorld"
+    // Lines: 1="", 2="", 3="World"
+    expect(updated.doc.lines).toBe(3);
+    expect(updated.doc.line(1).text).toBe("");
+    expect(updated.doc.line(2).text).toBe("");
+    expect(updated.doc.line(3).text).toBe("World");
+  });
+});

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -366,6 +366,55 @@ export function createEditorStateFromText(
   });
 }
 
+/**
+ * Unified document factory — CM doc holds the FULL .md text with claimed
+ * (wireframe) lines replaced by empty strings. Frames track which lines they
+ * own via docOffset (CM character offset of first claimed line) + lineCount.
+ *
+ * Empty strings (not " ") are used so preparedCache.ts maps them to the
+ * null fast-path and reflowLayout skips them as obstacle-bands instead of
+ * generating spurious PositionedLines.
+ */
+export function createEditorStateUnified(
+  text: string,
+  charWidth: number,
+  charHeight: number,
+): EditorState {
+  const { frames } = scanToFrames(text, charWidth, charHeight);
+
+  // Build set of source lines claimed by any top-level frame.
+  const claimedLines = new Set<number>();
+  for (const f of frames) {
+    for (let i = f.gridRow; i < f.gridRow + f.gridH; i++) {
+      claimedLines.add(i);
+    }
+  }
+
+  // Build unified doc: prose lines preserved, claimed lines → empty string.
+  const sourceLines = text.split("\n");
+  const unifiedLines = sourceLines.map((line, i) =>
+    claimedLines.has(i) ? "" : line,
+  );
+  const unifiedText = unifiedLines.join("\n");
+
+  // Recompute docOffset for each frame in the unified doc (line lengths shrank).
+  const lineOffsets: number[] = [];
+  {
+    let offset = 0;
+    for (let i = 0; i < unifiedLines.length; i++) {
+      lineOffsets.push(offset);
+      offset += unifiedLines[i].length + 1;
+    }
+  }
+  for (const f of frames) {
+    if (f.gridRow >= 0 && f.gridRow < lineOffsets.length) {
+      f.docOffset = lineOffsets[f.gridRow];
+    }
+  }
+
+  return createEditorState({ prose: unifiedText, frames });
+}
+
 // ── Accessors ──────────────────────────────────────────────────────────────
 
 export function getDoc(state: EditorState): string {

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -671,22 +671,54 @@ export function proseMoveRight(state: EditorState): EditorState {
   return state;
 }
 
+/** Find the claimed-line range covering `lineNum` (0-indexed), or null. */
+function getClaimedLineRange(
+  state: EditorState,
+  lineNum: number,
+): { start: number; end: number } | null {
+  const frames = state.field(framesField);
+  for (const f of frames) {
+    if (f.lineCount === 0) continue;
+    if (f.docOffset < 0 || f.docOffset > state.doc.length) continue;
+    const startLine = state.doc.lineAt(f.docOffset).number - 1; // 0-indexed
+    const endLine = startLine + f.lineCount - 1;
+    if (lineNum >= startLine && lineNum <= endLine) {
+      return { start: startLine, end: endLine };
+    }
+  }
+  return null;
+}
+
 export function proseMoveUp(state: EditorState): EditorState {
   const cursor = getCursor(state);
   if (!cursor) return state;
   if (cursor.row === 0) return state;
-  const prevLine = state.doc.line(cursor.row); // line above (1-indexed = cursor.row)
+  let targetRow = cursor.row - 1;
+  let claimed = getClaimedLineRange(state, targetRow);
+  while (claimed) {
+    targetRow = claimed.start - 1;
+    if (targetRow < 0) return state;
+    claimed = getClaimedLineRange(state, targetRow);
+  }
+  const prevLine = state.doc.line(targetRow + 1); // 1-indexed
   const prevGraphemes = [...segmenter.segment(prevLine.text)].length;
-  return moveCursorTo(state, { row: cursor.row - 1, col: Math.min(cursor.col, prevGraphemes) });
+  return moveCursorTo(state, { row: targetRow, col: Math.min(cursor.col, prevGraphemes) });
 }
 
 export function proseMoveDown(state: EditorState): EditorState {
   const cursor = getCursor(state);
   if (!cursor) return state;
   if (cursor.row >= state.doc.lines - 1) return state;
-  const nextLine = state.doc.line(cursor.row + 2); // line below (1-indexed = cursor.row + 2)
+  let targetRow = cursor.row + 1;
+  let claimed = getClaimedLineRange(state, targetRow);
+  while (claimed) {
+    targetRow = claimed.end + 1;
+    if (targetRow >= state.doc.lines) return state;
+    claimed = getClaimedLineRange(state, targetRow);
+  }
+  const nextLine = state.doc.line(targetRow + 1); // 1-indexed
   const nextGraphemes = [...segmenter.segment(nextLine.text)].length;
-  return moveCursorTo(state, { row: cursor.row + 1, col: Math.min(cursor.col, nextGraphemes) });
+  return moveCursorTo(state, { row: targetRow, col: Math.min(cursor.col, nextGraphemes) });
 }
 
 // ── Frame operations ───────────────────────────────────────────────────────

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -429,58 +429,100 @@ export function createEditorState(init: EditorStateInit): EditorState {
       if (e.is(moveFrameEffect) && e.value.dRow !== 0) {
         const frames = tr.startState.field(framesField);
         const frame = findFrameInList(frames, e.value.id);
-        // Only top-level frames claim doc lines (lineCount > 0).
         if (!frame || frame.lineCount === 0) continue;
 
         const doc = tr.startState.doc;
         const startLine = doc.lineAt(frame.docOffset);
         const endLineNum = startLine.number + frame.lineCount - 1;
+        if (endLineNum > doc.lines) continue; // claim is malformed; skip
         const endLine = doc.line(endLineNum);
 
-        // claimedContent = the raw bytes of the claimed lines (empty strings + newlines).
-        // For 3 empty lines this will be "\n\n" (the newline chars that ARE positions
-        // startLine.from through endLine.to - 1, i.e. the trailing newlines of each line).
-        const claimedContent = doc.sliceString(startLine.from, endLine.to);
+        // Vertical drag = swap newlines at the frame's boundaries.
+        // Drag down by 1 = delete \n above frame, insert \n below.
+        // Drag up by 1 = inverse. Net char count is 0; the frame's claimed
+        // empty lines stay empty; surrounding prose is untouched.
+        //
+        // For dRow=N, we rotate N newlines across the boundary.
 
-        // Compute target line number — clamped to doc bounds.
-        const targetLineNum = Math.max(1, Math.min(doc.lines, startLine.number + e.value.dRow));
-        if (targetLineNum === startLine.number) continue; // dRow is out-of-bounds no-op
+        const dRow = e.value.dRow;
+        const changes: Array<{ from: number; to: number; insert?: string }> = [];
 
-        // Determine delete range — include ONE boundary newline (the leading one if possible).
-        const deleteIncludesLeading = startLine.from > 0;
-        const deleteFrom = deleteIncludesLeading ? startLine.from - 1 : startLine.from;
-        const deleteTo = deleteIncludesLeading ? endLine.to : Math.min(endLine.to + 1, doc.length);
+        // Clamp dRow by counting consecutive EMPTY lines around the frame.
+        // Drag-down can absorb up to N empty lines below the frame.
+        // Drag-up can absorb up to N empty lines above the frame.
+        let maxDown = 0;
+        for (let n = endLineNum + 1; n <= doc.lines; n++) {
+          const ln = doc.line(n);
+          if (ln.length === 0) maxDown++;
+          else break;
+        }
+        let maxUp = 0;
+        for (let n = startLine.number - 1; n >= 1; n--) {
+          const ln = doc.line(n);
+          if (ln.length === 0) maxUp++;
+          else break;
+        }
+        const effectiveDRow = dRow > 0
+          ? Math.min(dRow, maxDown)
+          : Math.max(dRow, -maxUp);
+        if (effectiveDRow === 0) continue; // no room to move
 
-        // Compute rawInsertAt in ORIGINAL doc coordinates:
-        //   - drag down: insert at start of the line AFTER the target line (frame goes after target)
-        //   - drag up:   insert at start of the target line itself (frame goes before target)
-        const rawInsertAt = e.value.dRow > 0
-          ? doc.line(Math.min(doc.lines, targetLineNum + 1)).from
-          : doc.line(targetLineNum).from;
+        if (effectiveDRow > 0) {
+          // Drag down: for each step, take the newline AFTER the frame and
+          // move it to BEFORE the frame. Equivalently: delete one newline at
+          // endLine.to + (already-moved offset), insert one newline at
+          // startLine.from + (already-moved offset).
+          //
+          // For dRow steps, we delete `effectiveDRow` chars starting at
+          // endLine.to (those are the newlines following the frame, each
+          // belonging to a line below) and insert `effectiveDRow` chars
+          // starting at startLine.from.
+          // But pulling N chars from "after frame" pulls them from positions
+          // endLine.to .. endLine.to + effectiveDRow. The doc must have at
+          // least effectiveDRow characters there (i.e. effectiveDRow lines
+          // below). maxStartLine clamp guarantees this.
+          //
+          // Net effect: frame moves down by effectiveDRow rows, prose
+          // around it stays in its absolute positions.
+          const deleteFrom = endLine.to;
+          const deleteTo = endLine.to + effectiveDRow;
+          if (deleteTo > doc.length) {
+            // Defensive: clamp didn't fully prevent overflow; skip.
+            continue;
+          }
+          // The chars we're moving are newlines (since we're moving past
+          // empty prose lines). Insert the same number of newlines above.
+          const movedChars = doc.sliceString(deleteFrom, deleteTo);
+          changes.push({ from: deleteFrom, to: deleteTo });
+          changes.push({ from: startLine.from, to: startLine.from, insert: movedChars });
+        } else {
+          // Drag up by |effectiveDRow|. Mirror: take newlines from BEFORE the
+          // frame and move them AFTER.
+          const n = -effectiveDRow;
+          const deleteFrom2 = startLine.from - n;
+          const deleteTo2 = startLine.from;
+          if (deleteFrom2 < 0) continue;
+          const movedChars = doc.sliceString(deleteFrom2, deleteTo2);
+          // Delete the n newlines above the frame.
+          changes.push({ from: deleteFrom2, to: deleteTo2 });
+          // Insert them after the frame (at original endLine.to).
+          changes.push({ from: endLine.to, to: endLine.to, insert: movedChars });
+        }
 
-        // Map rawInsertAt through the deletion (sequential: true makes second spec see
-        // post-delete doc, so positions after the deleted range must be adjusted).
-        const mappedInsertAt = rawInsertAt > deleteTo
-          ? rawInsertAt - (deleteTo - deleteFrom)
-          : rawInsertAt;
-
-        const insertContent = deleteIncludesLeading
-          ? "\n" + claimedContent
-          : claimedContent + "\n";
-
-        // newDocOffset = position of the first claimed empty line in the final doc.
-        // The insert puts insertContent at mappedInsertAt; the first char of insertContent
-        // is the separator newline, so the frame content starts exactly at mappedInsertAt.
-        const newDocOffset = mappedInsertAt;
-
+        // newDocOffset for drag-down: frame's new startLine.from is the
+        // original startLine.from + 0 (chars inserted at startLine.from
+        // shift it forward by `effectiveDRow`, so docOffset += effectiveDRow).
+        // For drag-up: docOffset -= n, since we deleted n chars before it.
+        const newDocOffset = effectiveDRow > 0
+          ? startLine.from + effectiveDRow
+          : startLine.from - (-effectiveDRow);
+        // sliceString call signature note: changes already accumulated above
+        // reference ORIGINAL doc positions; we send them as a single changes
+        // array (CM merges them, applying both relative to the original doc).
         return [
           {
             effects: [...tr.effects, relocateFrameEffect.of({ id: frame.id, newDocOffset })],
-            changes: { from: deleteFrom, to: deleteTo },
-          },
-          {
-            changes: { from: mappedInsertAt, insert: insertContent },
-            sequential: true,
+            changes,
           },
         ];
       }

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -69,6 +69,11 @@ const restoreFramesEffect = StateEffect.define<Frame[]>();
 const clearDirtyEffect = StateEffect.define<null>();
 const setOriginalProseSegmentsEffect = StateEffect.define<ProseSegment[]>();
 
+// relocateFrameEffect — emitted by unifiedDocSync when a drag repositions a
+// top-level frame in the CM doc. Updates docOffset to the new claimed-line
+// start so framesField stays in sync with the doc change in the same transaction.
+const relocateFrameEffect = StateEffect.define<{ id: string; newDocOffset: number }>();
+
 // Mark a frame dirty by id, propagating up to ancestors.
 /** Recursively find a frame by id in a frame tree (incl. children). */
 function findFrameInList(frames: Frame[], id: string): Frame | null {
@@ -129,6 +134,11 @@ const framesField = StateField.define<Frame[]>({
         };
         result = result.map(applyMove);
         result = markDirtyById(result, e.value.id).frames;
+      } else if (e.is(relocateFrameEffect)) {
+        // Update docOffset to the new claimed-line start after drag.
+        result = result.map(f =>
+          f.id === e.value.id ? { ...f, docOffset: e.value.newDocOffset } : f,
+        );
       } else if (e.is(resizeFrameEffect)) {
         const applyResize = (f: Frame): Frame => {
           if (f.id === e.value.id) return resizeFrame(f, { gridW: e.value.gridW, gridH: e.value.gridH }, e.value.charWidth, e.value.charHeight);
@@ -326,9 +336,16 @@ export function createEditorState(init: EditorStateInit): EditorState {
   // snapshot the frames array before the transaction and emit a
   // restoreFramesEffect that replays it on undo.
   const frameInversion = invertedEffects.of((tr) => {
+    // Include restoreFramesEffect so that undo-of-undo (= redo) replays the
+    // correct frames: when the undo transaction carries restoreFramesEffect,
+    // we snapshot the pre-undo (= post-forward) frames and store them as the
+    // "redo effects". This is especially important for drag (Task 12) because
+    // the redo transaction has no original effects — only doc changes.
     const hasFrameEffect = tr.effects.some(
       (e) =>
         e.is(moveFrameEffect) ||
+        e.is(relocateFrameEffect) ||
+        e.is(restoreFramesEffect) ||
         e.is(resizeFrameEffect) ||
         e.is(addFrameEffect) ||
         e.is(deleteFrameEffect) ||
@@ -391,6 +408,64 @@ export function createEditorState(init: EditorStateInit): EditorState {
   // not re-fire on the merged transaction (programmatic edits go through).
   const unifiedDocSync = EditorState.transactionFilter.of((tr) => {
     for (const e of tr.effects) {
+      if (e.is(moveFrameEffect) && e.value.dRow !== 0) {
+        const frames = tr.startState.field(framesField);
+        const frame = findFrameInList(frames, e.value.id);
+        // Only top-level frames claim doc lines (lineCount > 0).
+        if (!frame || frame.lineCount === 0) continue;
+
+        const doc = tr.startState.doc;
+        const startLine = doc.lineAt(frame.docOffset);
+        const endLineNum = startLine.number + frame.lineCount - 1;
+        const endLine = doc.line(endLineNum);
+
+        // claimedContent = the raw bytes of the claimed lines (empty strings + newlines).
+        // For 3 empty lines this will be "\n\n" (the newline chars that ARE positions
+        // startLine.from through endLine.to - 1, i.e. the trailing newlines of each line).
+        const claimedContent = doc.sliceString(startLine.from, endLine.to);
+
+        // Compute target line number — clamped to doc bounds.
+        const targetLineNum = Math.max(1, Math.min(doc.lines, startLine.number + e.value.dRow));
+        if (targetLineNum === startLine.number) continue; // dRow is out-of-bounds no-op
+
+        // Determine delete range — include ONE boundary newline (the leading one if possible).
+        const deleteIncludesLeading = startLine.from > 0;
+        const deleteFrom = deleteIncludesLeading ? startLine.from - 1 : startLine.from;
+        const deleteTo = deleteIncludesLeading ? endLine.to : Math.min(endLine.to + 1, doc.length);
+
+        // Compute rawInsertAt in ORIGINAL doc coordinates:
+        //   - drag down: insert at start of the line AFTER the target line (frame goes after target)
+        //   - drag up:   insert at start of the target line itself (frame goes before target)
+        const rawInsertAt = e.value.dRow > 0
+          ? doc.line(Math.min(doc.lines, targetLineNum + 1)).from
+          : doc.line(targetLineNum).from;
+
+        // Map rawInsertAt through the deletion (sequential: true makes second spec see
+        // post-delete doc, so positions after the deleted range must be adjusted).
+        const mappedInsertAt = rawInsertAt > deleteTo
+          ? rawInsertAt - (deleteTo - deleteFrom)
+          : rawInsertAt;
+
+        const insertContent = deleteIncludesLeading
+          ? "\n" + claimedContent
+          : claimedContent + "\n";
+
+        // newDocOffset = position of the first claimed empty line in the final doc.
+        // The insert puts insertContent at mappedInsertAt; the first char of insertContent
+        // is the separator newline, so the frame content starts exactly at mappedInsertAt.
+        const newDocOffset = mappedInsertAt;
+
+        return [
+          {
+            effects: [...tr.effects, relocateFrameEffect.of({ id: frame.id, newDocOffset })],
+            changes: { from: deleteFrom, to: deleteTo },
+          },
+          {
+            changes: { from: mappedInsertAt, insert: insertContent },
+            sequential: true,
+          },
+        ];
+      }
       if (e.is(resizeFrameEffect)) {
         const frames = tr.startState.field(framesField);
         const frame = findFrameInList(frames, e.value.id);

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -70,6 +70,16 @@ const clearDirtyEffect = StateEffect.define<null>();
 const setOriginalProseSegmentsEffect = StateEffect.define<ProseSegment[]>();
 
 // Mark a frame dirty by id, propagating up to ancestors.
+/** Recursively find a frame by id in a frame tree (incl. children). */
+function findFrameInList(frames: Frame[], id: string): Frame | null {
+  for (const f of frames) {
+    if (f.id === id) return f;
+    const found = findFrameInList(f.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
 function markDirtyById(frames: Frame[], id: string): { frames: Frame[]; found: boolean } {
   let found = false;
   const result = frames.map(f => {
@@ -127,6 +137,12 @@ const framesField = StateField.define<Frame[]>({
         };
         result = result.map(applyResize);
         result = markDirtyById(result, e.value.id).frames;
+        // Sync lineCount with new gridH for top-level frames that claim doc lines.
+        result = result.map(f =>
+          f.id === e.value.id && f.lineCount > 0
+            ? { ...f, lineCount: Math.max(2, e.value.gridH) }
+            : f,
+        );
       } else if (e.is(addFrameEffect)) {
         result = [...result, { ...e.value, dirty: true }];
       } else if (e.is(deleteFrameEffect)) {
@@ -367,10 +383,50 @@ export function createEditorState(init: EditorStateInit): EditorState {
     return !intersects;
   });
 
+  // unifiedDocSync: intercept frame mutation effects and add doc changes
+  // that keep the CM doc in sync with the frame model. Empty-string lines
+  // (per Task 3 audit correction) are inserted/removed as the frame grows
+  // or shrinks. When this filter returns an array of specs, CM merges them
+  // via resolveTransaction(state, filtered, false), so changeFilter does
+  // not re-fire on the merged transaction (programmatic edits go through).
+  const unifiedDocSync = EditorState.transactionFilter.of((tr) => {
+    for (const e of tr.effects) {
+      if (e.is(resizeFrameEffect)) {
+        const frames = tr.startState.field(framesField);
+        const frame = findFrameInList(frames, e.value.id);
+        if (!frame || frame.lineCount === 0) continue;
+
+        const newGridH = Math.max(2, e.value.gridH);
+        const delta = newGridH - frame.lineCount;
+        if (delta === 0) continue;
+
+        const startLine = tr.startState.doc.lineAt(frame.docOffset);
+        const endLineNum = startLine.number + frame.lineCount - 1;
+        const endLine = tr.startState.doc.line(endLineNum);
+
+        if (delta > 0) {
+          // Insert `delta` empty lines AFTER the current claimed range.
+          // Each new line is just "\n" (empty string content).
+          const insert = "\n".repeat(delta);
+          return [tr, { changes: { from: endLine.to, insert }, sequential: true }];
+        } else {
+          // Remove `-delta` lines from the end of the claimed range.
+          // endLineNum + delta + 1 is the first line to keep at the bottom.
+          // Delete from end of (endLineNum + delta) through end of endLine.
+          const keepLastNum = endLineNum + delta; // last claimed line we keep
+          const keepLast = tr.startState.doc.line(keepLastNum);
+          return [tr, { changes: { from: keepLast.to, to: endLine.to }, sequential: true }];
+        }
+      }
+    }
+    return tr;
+  });
+
   const extensions: Extension[] = [
     history(),
     frameInversion,
     claimFilter,
+    unifiedDocSync,
     framesField.init(() => frames),
     selectedIdField,
     textEditField,

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -235,6 +235,24 @@ const framesField = StateField.define<Frame[]>({
         result = markDirtyById(result, e.value.id).frames;
       }
     }
+    // gridRow sync: for top-level claiming frames (lineCount > 0), gridRow is
+    // a CACHE of "what doc line does docOffset land on". moveFrame() updates
+    // gridRow blindly by dRow; unifiedDocSync may clamp the doc-side
+    // position. The doc is the single source of truth — re-derive gridRow
+    // here so the serializer (which reads gridRow) never sees drift.
+    // Child frames (lineCount === 0) keep their parent-relative gridRow.
+    const docLen = tr.newDoc.length;
+    const docLines = tr.newDoc.lines;
+    result = result.map(f => {
+      if (f.lineCount === 0) return f;
+      if (f.docOffset < 0 || f.docOffset > docLen) return f;
+      const lineNum = tr.newDoc.lineAt(f.docOffset).number - 1; // 0-indexed
+      if (lineNum === f.gridRow) return f;
+      // Clamp lineCount so gridRow + lineCount stays within doc.
+      const maxLineCount = Math.max(1, docLines - lineNum);
+      const lineCount = Math.min(f.lineCount, maxLineCount);
+      return { ...f, gridRow: lineNum, lineCount };
+    });
     return result;
   },
 });

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -436,6 +436,19 @@ export function createEditorState(init: EditorStateInit): EditorState {
         const to = startLine.from > 0 ? endLine.to : Math.min(endLine.to + 1, docLength);
         return [tr, { changes: { from, to }, sequential: true }];
       }
+      if (e.is(addFrameEffect)) {
+        const newFrame = e.value;
+        // Child frames (lineCount===0) don't claim doc lines — skip.
+        if (newFrame.lineCount === 0) continue;
+
+        const doc = tr.startState.doc;
+        const offset = Math.max(0, Math.min(newFrame.docOffset, doc.length));
+        // Insert `lineCount` newlines at `offset`. Each "\n" creates one
+        // new empty line. The inserted chars become the claimed blank lines.
+        // Empty content (not " ") satisfies preparedCache null fast-path.
+        const insert = "\n".repeat(newFrame.lineCount);
+        return [tr, { changes: { from: offset, insert }, sequential: true }];
+      }
     }
     return tr;
   });

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -418,6 +418,24 @@ export function createEditorState(init: EditorStateInit): EditorState {
           return [tr, { changes: { from: keepLast.to, to: endLine.to }, sequential: true }];
         }
       }
+      if (e.is(deleteFrameEffect)) {
+        const frames = tr.startState.field(framesField);
+        const frame = findFrameInList(frames, e.value.id);
+        // Skip child frames (lineCount===0) — they don't claim doc lines.
+        if (!frame || frame.lineCount === 0) continue;
+
+        const startLine = tr.startState.doc.lineAt(frame.docOffset);
+        const endLineNum = startLine.number + frame.lineCount - 1;
+        const endLine = tr.startState.doc.line(endLineNum);
+        const docLength = tr.startState.doc.length;
+
+        // Delete exactly ONE newline (the boundary separator), not both.
+        // Frame at file start: trailing newline is the only separator → from=0, to=endLine.to + 1
+        // Frame elsewhere: leading newline is the separator → from=startLine.from - 1, to=endLine.to
+        const from = startLine.from > 0 ? startLine.from - 1 : 0;
+        const to = startLine.from > 0 ? endLine.to : Math.min(endLine.to + 1, docLength);
+        return [tr, { changes: { from, to }, sequential: true }];
+      }
     }
     return tr;
   });

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -88,6 +88,18 @@ const framesField = StateField.define<Frame[]>({
   create: () => [],
   update(frames, tr: Transaction) {
     let result = frames;
+    // Remap docOffset on every doc-changing transaction. Use associativity=1
+    // so frames follow preceding insertions (Enter-above-wireframe pushes
+    // frame down). Also re-runs on undo, where the inverted ChangeSet maps
+    // offsets back; restoreFramesEffect (below) overrides this for frame
+    // mutations, but pure prose edits land here exclusively.
+    if (tr.docChanged) {
+      result = result.map((f) =>
+        f.lineCount === 0
+          ? f
+          : { ...f, docOffset: tr.changes.mapPos(f.docOffset, 1) },
+      );
+    }
     for (const e of tr.effects) {
       if (e.is(restoreFramesEffect)) {
         return e.value;
@@ -342,6 +354,10 @@ export function createEditorState(init: EditorStateInit): EditorState {
     let intersects = false;
     tr.changes.iterChangedRanges((fromA, toA) => {
       for (const r of claimed) {
+        // Pure insertion (fromA === toA) AT a claimed-range boundary is
+        // BEFORE the claim (associativity=1 will push the frame forward).
+        // Allow these so "Enter at end of prose line above wireframe" works.
+        if (fromA === toA && (fromA === r.from || fromA === r.to + 1)) continue;
         if (fromA <= r.to && toA >= r.from) {
           intersects = true;
           break;

--- a/src/editorState.ts
+++ b/src/editorState.ts
@@ -313,9 +313,48 @@ export function createEditorState(init: EditorStateInit): EditorState {
     return [restoreFramesEffect.of(tr.startState.field(framesField))];
   });
 
+  // changeFilter: reject user-initiated edits that touch any frame-claimed
+  // line range. Programmatic transactions (no userEvent) are bypassed so the
+  // mutation transactionFilter (Tasks 10-13) can splice claimed lines on
+  // move/resize/delete. Note: when a transactionFilter returns an array of
+  // specs, CM merges them via resolveTransaction(state, filtered, false) —
+  // the `false` skips re-applying changeFilter, so this is consistent.
+  const claimFilter = EditorState.changeFilter.of((tr) => {
+    if (!tr.isUserEvent("input") && !tr.isUserEvent("delete")) return true;
+    const frames = tr.startState.field(framesField);
+    if (frames.length === 0) return true;
+    const claimed: Array<{ from: number; to: number }> = [];
+    const docLen = tr.startState.doc.length;
+    for (const f of frames) {
+      if (f.lineCount === 0) continue;
+      // Defensive: a frame's docOffset is only meaningful in the unified-doc
+      // factory. Other factories (the legacy prose-only path) leave docOffset
+      // pointing into the longer source text; skip those rather than crash.
+      if (f.docOffset < 0 || f.docOffset > docLen) continue;
+      const startLine = tr.startState.doc.lineAt(f.docOffset);
+      const endLineNum = Math.min(
+        startLine.number + f.lineCount - 1,
+        tr.startState.doc.lines,
+      );
+      const endLine = tr.startState.doc.line(endLineNum);
+      claimed.push({ from: startLine.from, to: endLine.to });
+    }
+    let intersects = false;
+    tr.changes.iterChangedRanges((fromA, toA) => {
+      for (const r of claimed) {
+        if (fromA <= r.to && toA >= r.from) {
+          intersects = true;
+          break;
+        }
+      }
+    });
+    return !intersects;
+  });
+
   const extensions: Extension[] = [
     history(),
     frameInversion,
+    claimFilter,
     framesField.init(() => frames),
     selectedIdField,
     textEditField,
@@ -337,12 +376,17 @@ export function createEditorState(init: EditorStateInit): EditorState {
 }
 
 // Convenience factory — runs scanToFrames internally.
+// Legacy path: builds a CM doc with prose only (wireframe lines stripped).
+// Frame.docOffset values from scanToFrames refer to the FULL source text,
+// not this shrunken prose doc — clear them so the unified-doc claimFilter
+// (which sees lineCount=0) treats these frames as non-claiming.
 export function createEditorStateFromText(
   text: string,
   charWidth: number,
   charHeight: number,
 ): EditorState {
   const { frames, proseSegments } = scanToFrames(text, charWidth, charHeight);
+  for (const f of frames) { f.docOffset = 0; f.lineCount = 0; }
   const byRow = new Map<number, string>();
   for (const seg of proseSegments) {
     const existing = byRow.get(seg.row) ?? "";

--- a/src/frame.test.ts
+++ b/src/frame.test.ts
@@ -238,3 +238,50 @@ describe("Fix 1: wire chars should not leak into prose", () => {
     expect(mixedTexts.length).toBeGreaterThan(0);
   });
 });
+
+describe("Frame docOffset/lineCount", () => {
+  it("createFrame includes docOffset and lineCount defaults", () => {
+    const f = createFrame({ x: 0, y: 0, w: 100, h: 50 });
+    expect(f.docOffset).toBe(0);
+    expect(f.lineCount).toBe(0);
+  });
+
+  it("createRectFrame includes docOffset and lineCount defaults", () => {
+    const f = createRectFrame({
+      gridW: 10,
+      gridH: 5,
+      style: { tl: "┌", tr: "┐", bl: "└", br: "┘", h: "─", v: "│" },
+      charWidth: CW,
+      charHeight: CH,
+    });
+    expect(f.docOffset).toBe(0);
+    expect(f.lineCount).toBe(0);
+  });
+
+  it("createTextFrame includes docOffset and lineCount defaults", () => {
+    const f = createTextFrame({ text: "hi", row: 2, col: 3, charWidth: CW, charHeight: CH });
+    expect(f.docOffset).toBe(0);
+    expect(f.lineCount).toBe(0);
+  });
+
+  it("createLineFrame includes docOffset and lineCount defaults", () => {
+    const f = createLineFrame({ r1: 0, c1: 0, r2: 0, c2: 5, charWidth: CW, charHeight: CH });
+    expect(f.docOffset).toBe(0);
+    expect(f.lineCount).toBe(0);
+  });
+
+  it("groupIntoContainers (via framesFromScan) sets docOffset/lineCount on container", () => {
+    // Two side-by-side rects in same row range — produces a container
+    const scanResult = scan("┌─┐ ┌─┐\n│ │ │ │\n└─┘ └─┘");
+    const frames = framesFromScan(scanResult, CW, CH);
+    expect(frames).toHaveLength(1);
+    const container = frames[0];
+    expect(container.docOffset).toBe(0);
+    expect(container.lineCount).toBe(0);
+    expect(container.children.length).toBeGreaterThan(0);
+    for (const child of container.children) {
+      expect(child.docOffset).toBe(0);
+      expect(child.lineCount).toBe(0);
+    }
+  });
+});

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -41,6 +41,10 @@ export interface Frame {
   gridCol: number;
   gridW: number;
   gridH: number;
+  /** CM doc character offset — start of first claimed line. 0 = not yet placed. */
+  docOffset: number;
+  /** Number of CM doc lines this frame claims. 0 = not yet placed. */
+  lineCount: number;
 }
 
 export interface Obstacle {
@@ -82,6 +86,8 @@ export function createFrame(params: {
     gridCol: 0,
     gridW: 0,
     gridH: 0,
+    docOffset: 0,
+    lineCount: 0,
   };
 }
 
@@ -111,6 +117,8 @@ export function createRectFrame(params: {
     gridRow: 0, gridCol: 0, // caller sets position
     gridW,
     gridH,
+    docOffset: 0,
+    lineCount: 0,
   };
 }
 
@@ -144,6 +152,8 @@ export function createTextFrame(params: {
     gridCol: col,
     gridW: codepoints.length,
     gridH: 1,
+    docOffset: 0,
+    lineCount: 0,
   };
 }
 
@@ -174,6 +184,8 @@ export function createLineFrame(params: {
     gridCol: bbox.col,
     gridW: bbox.w,
     gridH: bbox.h,
+    docOffset: 0,
+    lineCount: 0,
   };
 }
 
@@ -340,7 +352,7 @@ export function framesFromScan(
       content = { type: "rect", cells: rebasedCells, style: { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" } };
     }
 
-    return { id: nextId(), x, y, w, h, z: 0, children: [], content, clip: true, dirty: false, gridRow: layer.bbox.row, gridCol: layer.bbox.col, gridW: layer.bbox.w, gridH: layer.bbox.h };
+    return { id: nextId(), x, y, w, h, z: 0, children: [], content, clip: true, dirty: false, gridRow: layer.bbox.row, gridCol: layer.bbox.col, gridW: layer.bbox.w, gridH: layer.bbox.h, docOffset: 0, lineCount: 0 };
   });
 
   reparentChildren(frames, charWidth, charHeight);
@@ -479,6 +491,8 @@ function groupIntoContainers(
       gridCol: minCol,
       gridW: maxCol - minCol,
       gridH: maxRow - minRow,
+      docOffset: 0,
+      lineCount: 0,
     });
   }
 

--- a/src/gridSerialize.test.ts
+++ b/src/gridSerialize.test.ts
@@ -225,7 +225,7 @@ describe("Fix 3: recursive dirty detection", () => {
       children: [],
       clip: true,
       dirty: true, // child is dirty — it moved
-      gridRow: 0, gridCol: 0, gridW: 4, gridH: 3, // now at absolute row 0
+      gridRow: 0, gridCol: 0, gridW: 4, gridH: 3, docOffset: 0, lineCount: 0, // now at absolute row 0
       content: {
         type: "rect",
         cells: new Map([
@@ -243,7 +243,7 @@ describe("Fix 3: recursive dirty detection", () => {
       children: [childRect],
       clip: true,
       dirty: false, // container is clean — only the child moved
-      gridRow: 0, gridCol: 0, gridW: 4, gridH: 3,
+      gridRow: 0, gridCol: 0, gridW: 4, gridH: 3, docOffset: 0, lineCount: 0,
       content: null,
     };
 
@@ -305,7 +305,7 @@ describe("Fix 3: recursive dirty detection", () => {
       children: [],
       clip: true,
       dirty: true, // child dirty — triggers reflow
-      gridRow: 0, gridCol: 0, gridW: 4, gridH: 3,
+      gridRow: 0, gridCol: 0, gridW: 4, gridH: 3, docOffset: 0, lineCount: 0,
       content: {
         type: "rect",
         cells: new Map([
@@ -322,7 +322,7 @@ describe("Fix 3: recursive dirty detection", () => {
       children: [childRect],
       clip: true,
       dirty: false, // container is NOT dirty
-      gridRow: 1, gridCol: 0, gridW: 4, gridH: 3,
+      gridRow: 1, gridCol: 0, gridW: 4, gridH: 3, docOffset: 0, lineCount: 0,
       content: null,
     };
 
@@ -372,6 +372,8 @@ function fakeFrame(gridRow: number, gridH: number): Frame {
     gridCol: 0,
     gridW: 10,
     gridH,
+    docOffset: 0,
+    lineCount: 0,
   };
 }
 
@@ -470,7 +472,7 @@ describe("Fix 4: per-cell clipping in collectFrameCells", () => {
       children: [],
       clip: true,
       dirty: true,
-      gridRow: 0, gridCol: 0, gridW: 6, gridH: 3,
+      gridRow: 0, gridCol: 0, gridW: 6, gridH: 3, docOffset: 0, lineCount: 0,
       content: {
         type: "rect",
         cells: new Map([
@@ -489,7 +491,7 @@ describe("Fix 4: per-cell clipping in collectFrameCells", () => {
       children: [],
       clip: true,
       dirty: true,
-      gridRow: 1, gridCol: 3, gridW: 4, gridH: 1,
+      gridRow: 1, gridCol: 3, gridW: 4, gridH: 1, docOffset: 0, lineCount: 0,
       content: {
         type: "text",
         cells: new Map([
@@ -538,7 +540,7 @@ describe("Fix 4: per-cell clipping in collectFrameCells", () => {
       children: [],
       clip: true,
       dirty: true,
-      gridRow: 0, gridCol: 0, gridW: 4, gridH: 2,
+      gridRow: 0, gridCol: 0, gridW: 4, gridH: 2, docOffset: 0, lineCount: 0,
       content: {
         type: "rect",
         cells: new Map([
@@ -552,7 +554,7 @@ describe("Fix 4: per-cell clipping in collectFrameCells", () => {
     // row 2 (absolute) overflows (parent gridH=2 → rows 0..1 only)
     const childMultiRow: Frame = {
       id: "multirow1",
-      x: 8, y: 8, w: 8, h: 32, z: 0,
+      x: 8, y: 8, w: 8, h: 32, z: 0, docOffset: 0, lineCount: 0,
       children: [],
       clip: true,
       dirty: true,

--- a/src/reflowLayout.test.ts
+++ b/src/reflowLayout.test.ts
@@ -204,6 +204,75 @@ describe("reflowLayout per-line cache equivalence", () => {
   });
 });
 
+describe("reflowLayout under unified-doc model (empty claimed lines)", () => {
+  // In the unified-doc model, wireframe rows are stored as empty strings ("") in
+  // the CM doc. buildPreparedCache maps "" → null (preparedCache.ts:12).
+  // reflowLayout.ts:98-107 handles null by advancing lineTop without emitting a
+  // PositionedLine. These tests lock in that contract.
+
+  it("prose with single empty claimed line skips that row", () => {
+    // Simulates: prose row 0, claimed (wireframe) row 1, prose row 2
+    // obstacle covers row 1 (y=LH, h=LH)
+    const prosePrepared = prepareWithSegments("Hello world", FONT, { whiteSpace: "pre-wrap" });
+    const preparedLines = [prosePrepared, null, prosePrepared];
+    const obstacle: Obstacle = { x: 0, y: LH, w: 600, h: LH };
+    const result = reflowLayout(preparedLines, 9999, LH, [obstacle]);
+
+    // Should get exactly 2 PositionedLines — one for index 0 and one for index 2
+    expect(result.lines.length).toBe(2);
+    expect(result.lines[0].sourceLine).toBe(0);
+    expect(result.lines[1].sourceLine).toBe(2);
+    // The second prose line must start at or after the obstacle bottom
+    expect(result.lines[1].y).toBeGreaterThanOrEqual(obstacle.y + obstacle.h);
+  });
+
+  it("prose with multiple consecutive empty claimed lines skips all of them", () => {
+    // Simulates 3 consecutive wireframe rows claimed in the doc
+    // obstacle spans rows 1-3 (y=LH, h=3*LH)
+    const prosePrepared = prepareWithSegments("Some text", FONT, { whiteSpace: "pre-wrap" });
+    const preparedLines = [prosePrepared, null, null, null, prosePrepared];
+    const obstacle: Obstacle = { x: 0, y: LH, w: 600, h: 3 * LH };
+    const result = reflowLayout(preparedLines, 9999, LH, [obstacle]);
+
+    // Should only emit 2 PositionedLines — one per prose entry
+    expect(result.lines.length).toBe(2);
+    expect(result.lines[0].sourceLine).toBe(0);
+    expect(result.lines[1].sourceLine).toBe(4);
+    // Second prose must start below the entire obstacle
+    expect(result.lines[1].y).toBeGreaterThanOrEqual(obstacle.y + obstacle.h);
+  });
+
+  it("prose flows around obstacle when claimed lines are present", () => {
+    // A paragraph above (row 0 prose) and an obstacle at rows 1-2 and more prose at row 3.
+    // Verify no PositionedLine lands inside the obstacle band.
+    const prosePrepared = prepareWithSegments("Quick brown fox", FONT, { whiteSpace: "pre-wrap" });
+    const obstacle: Obstacle = { x: 0, y: LH, w: 600, h: 2 * LH };
+    const preparedLines = [prosePrepared, null, null, prosePrepared];
+    const result = reflowLayout(preparedLines, 9999, LH, [obstacle]);
+
+    const insideObstacle = result.lines.filter(
+      l => l.y + LH > obstacle.y && l.y < obstacle.y + obstacle.h
+    );
+    expect(insideObstacle.length).toBe(0);
+    // Still have output lines
+    expect(result.lines.length).toBeGreaterThan(0);
+  });
+
+  it("empty claimed line at start of doc still advances lineTop", () => {
+    // Claimed row 0 (wireframe at top), prose at row 1.
+    // obstacle at y=0, h=LH.
+    const prosePrepared = prepareWithSegments("First real prose", FONT, { whiteSpace: "pre-wrap" });
+    const obstacle: Obstacle = { x: 0, y: 0, w: 600, h: LH };
+    const preparedLines = [null, prosePrepared];
+    const result = reflowLayout(preparedLines, 9999, LH, [obstacle]);
+
+    expect(result.lines.length).toBeGreaterThanOrEqual(1);
+    // The prose line must start at or after y = LH (obstacle bottom)
+    expect(result.lines[0].y).toBeGreaterThanOrEqual(LH);
+    expect(result.lines[0].sourceLine).toBe(1);
+  });
+});
+
 describe("reflowLayout PositionedLine metadata", () => {
   it("each line has endCursor and slotWidth", () => {
     const result = reflowLayout(prepareLines("Hello\nWorld"), 9999, LH, []);

--- a/src/reflowLayout.ts
+++ b/src/reflowLayout.ts
@@ -51,29 +51,6 @@ export interface ReflowResult {
   totalHeight: number;
 }
 
-interface Interval {
-  left: number;
-  right: number;
-}
-
-// From editorial-engine.ts — carve available slots from blocked intervals
-function carveSlots(base: Interval, blocked: Interval[]): Interval[] {
-  let slots = [base];
-  for (const interval of blocked) {
-    const next: Interval[] = [];
-    for (const slot of slots) {
-      if (interval.right <= slot.left || interval.left >= slot.right) {
-        next.push(slot);
-        continue;
-      }
-      if (interval.left > slot.left) next.push({ left: slot.left, right: interval.left });
-      if (interval.right < slot.right) next.push({ left: interval.right, right: slot.right });
-    }
-    slots = next;
-  }
-  return slots.filter(s => s.right - s.left >= 20); // min slot width
-}
-
 function buildSegToCol(prepared: PreparedTextWithSegments): number[] {
   const result: number[] = [];
   let col = 0;

--- a/src/scanToFrames.test.ts
+++ b/src/scanToFrames.test.ts
@@ -64,3 +64,36 @@ describe("scanToFrames (grid-based)", () => {
     expect(originalGrid).toHaveLength(0);
   });
 });
+
+describe("scanToFrames docOffset/lineCount", () => {
+  it("sets docOffset and lineCount for a simple wireframe", () => {
+    const text = "Hello world\n\n┌──────┐\n│ Box  │\n└──────┘\n\nGoodbye";
+    const result = scanToFrames(text, 9.6, 18);
+    const frames = result.frames;
+    expect(frames.length).toBeGreaterThanOrEqual(1);
+    const rect = frames[0];
+    expect(rect.lineCount).toBe(3);
+    // "Hello world\n" = 12 chars, plus "\n" = 13 → start of line 2 (0-indexed)
+    expect(rect.docOffset).toBe(13);
+  });
+
+  it("sets docOffset for wireframe not at start of file", () => {
+    const text = "Line one\nLine two\nLine three\n┌────┐\n│ Hi │\n└────┘";
+    const result = scanToFrames(text, 9.6, 18);
+    const frames = result.frames;
+    expect(frames.length).toBeGreaterThanOrEqual(1);
+    const rect = frames[0];
+    expect(rect.lineCount).toBe(3);
+    // "Line one\n" = 9, "Line two\n" = 9, "Line three\n" = 11 → 29
+    expect(rect.docOffset).toBe(29);
+  });
+
+  it("sets docOffset=0 and lineCount=gridH for wireframe at file start", () => {
+    const text = "┌──┐\n│Hi│\n└──┘\nbye";
+    const result = scanToFrames(text, 9.6, 18);
+    expect(result.frames.length).toBeGreaterThanOrEqual(1);
+    const rect = result.frames[0];
+    expect(rect.docOffset).toBe(0);
+    expect(rect.lineCount).toBe(3);
+  });
+});

--- a/src/scanToFrames.ts
+++ b/src/scanToFrames.ts
@@ -52,6 +52,25 @@ export function scanToFrames(
   const scanResult = scan(text);
   const frames = framesFromScan(scanResult, charWidth, charHeight);
 
+  // Compute docOffset + lineCount from source text line offsets.
+  // A top-level frame's gridRow is its 0-indexed source line number.
+  const sourceLines = text.split("\n");
+  const lineOffsets: number[] = [];
+  {
+    let offset = 0;
+    for (let i = 0; i < sourceLines.length; i++) {
+      lineOffsets.push(offset);
+      offset += sourceLines[i].length + 1; // +1 for \n
+    }
+  }
+  for (const f of frames) {
+    const startLine = f.gridRow;
+    if (startLine >= 0 && startLine < lineOffsets.length) {
+      f.docOffset = lineOffsets[startLine];
+      f.lineCount = f.gridH;
+    }
+  }
+
   // Collect frame bboxes for prose extraction
   const frameBboxes = scanResult.rects.map(r => ({
     row: r.row, col: r.col, w: r.w, h: r.h,

--- a/src/serializeUnified.test.ts
+++ b/src/serializeUnified.test.ts
@@ -129,6 +129,48 @@ No wireframes here`;
     expect(result).toBe(prose);
   });
 
+  it("round-trips junction wireframe with bottom-row labels", () => {
+    // Reproduces e2e harness "no-edit: junction-chars" failure.
+    // The bottom-row labels "Bottom L" / "Bottom R" are missing from output
+    // even though the input clearly has them.
+    const original = `Header
+
+┌───────────┬───────────┐
+│  Left     │  Right    │
+├───────────┼───────────┤
+│  Bottom L │  Bottom R │
+└───────────┴───────────┘
+
+Footer`;
+    const { unifiedDoc, frames } = buildUnifiedDoc(original);
+    const result = serializeUnified(unifiedDoc, frames);
+    expect(result).toContain("Bottom L");
+    expect(result).toContain("Bottom R");
+    expect(result).toBe(original);
+  });
+
+  it("round-trips form-layout with multi-row label/box pairs", () => {
+    // Reproduces "no-edit: form-layout" failure. The "Name:" label is missing.
+    const original = `Form
+
+┌──────────────────────────┐
+│      Title               │
+├──────────────────────────┤
+│  Name:  ┌─────────────┐  │
+│         │             │  │
+│         └─────────────┘  │
+│  Email: ┌─────────────┐  │
+│         │             │  │
+│         └─────────────┘  │
+└──────────────────────────┘
+
+End`;
+    const { unifiedDoc, frames } = buildUnifiedDoc(original);
+    const result = serializeUnified(unifiedDoc, frames);
+    expect(result).toContain("Name:");
+    expect(result).toContain("Email:");
+  });
+
   it("frame with lineCount === 0 is ignored", () => {
     const original = `Hello world`;
     const { frames } = scanToFrames(original, 9.6, 18);

--- a/src/serializeUnified.test.ts
+++ b/src/serializeUnified.test.ts
@@ -1,0 +1,152 @@
+// src/serializeUnified.test.ts
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { serializeUnified } from "./serializeUnified";
+import { scanToFrames } from "./scanToFrames";
+import { framesFromScan } from "./frame";
+import { scan } from "./scanner";
+
+// Canvas mock for scanner/framesFromScan
+beforeAll(() => {
+  const origCreateElement = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    const el = origCreateElement(tag);
+    if (tag === "canvas") {
+      // @ts-expect-error mocking canvas getContext for tests
+      el.getContext = () => ({
+        font: "", fillStyle: "", textBaseline: "",
+        fillText: () => {},
+        measureText: (text: string) => ({
+          width: text.length * 9.6,
+          actualBoundingBoxAscent: 12,
+          actualBoundingBoxDescent: 4,
+        }),
+      });
+    }
+    return el;
+  });
+});
+
+/** Helper: build the unified doc from original text + scanToFrames output */
+function buildUnifiedDoc(original: string, cw = 9.6, ch = 18): { unifiedDoc: string; frames: ReturnType<typeof scanToFrames>["frames"] } {
+  const { frames } = scanToFrames(original, cw, ch);
+  const sourceLines = original.split("\n");
+  const claimedLines = new Set<number>();
+  for (const f of frames) {
+    for (let i = f.gridRow; i < f.gridRow + f.gridH; i++) {
+      claimedLines.add(i);
+    }
+  }
+  const unifiedDoc = sourceLines
+    .map((line, i) => (claimedLines.has(i) ? " " : line))
+    .join("\n");
+  return { unifiedDoc, frames };
+}
+
+describe("serializeUnified", () => {
+  it("round-trips a simple wireframe with prose", () => {
+    const original = `Hello world
+
+┌──────┐
+│ Box  │
+└──────┘
+
+Goodbye`;
+    const { unifiedDoc, frames } = buildUnifiedDoc(original);
+    const result = serializeUnified(unifiedDoc, frames);
+    expect(result).toBe(original);
+  });
+
+  it("round-trips wireframe at start of file", () => {
+    const original = `┌──────┐
+│ Test │
+└──────┘
+Some prose`;
+    const { unifiedDoc, frames } = buildUnifiedDoc(original);
+    const result = serializeUnified(unifiedDoc, frames);
+    expect(result).toBe(original);
+  });
+
+  it("round-trips wireframe at end of file (no trailing newline)", () => {
+    const original = `Intro text
+┌────┐
+│ Hi │
+└────┘`;
+    const { unifiedDoc, frames } = buildUnifiedDoc(original);
+    const result = serializeUnified(unifiedDoc, frames);
+    expect(result).toBe(original);
+  });
+
+  it("round-trips two separated wireframes with prose between", () => {
+    // Two blank lines of separation to avoid groupIntoContainers merging them
+    const original = `First frame:
+┌───┐
+│ A │
+└───┘
+
+Between lines
+
+┌───┐
+│ B │
+└───┘
+After`;
+    const { unifiedDoc, frames } = buildUnifiedDoc(original);
+    const result = serializeUnified(unifiedDoc, frames);
+    expect(result).toBe(original);
+  });
+
+  it("renders frame children at correct relative positions", () => {
+    // Container with two side-by-side children — use framesFromScan directly
+    const original = `┌──┐┌──┐
+│ A││ B│
+└──┘└──┘`;
+    const cw = 9.6, ch = 18;
+    const scanResult = scan(original);
+    const frames = framesFromScan(scanResult, cw, ch);
+    // Manually set docOffset + lineCount for the container
+    for (const f of frames) {
+      f.docOffset = 0;
+      f.lineCount = f.gridH;
+    }
+    // Build unified doc with all lines claimed
+    const allClaimed = original.split("\n").map(() => " ").join("\n");
+    const result = serializeUnified(allClaimed, frames);
+    // Both boxes should appear in output
+    expect(result).toContain("┌──┐");
+    expect(result).toContain("│ A│");
+    expect(result).toContain("│ B│");
+  });
+
+  it("empty doc returns empty string", () => {
+    const result = serializeUnified("", []);
+    expect(result).toBe("");
+  });
+
+  it("prose-only doc passes through unchanged", () => {
+    const prose = `Hello world
+This is prose only
+No wireframes here`;
+    const result = serializeUnified(prose, []);
+    expect(result).toBe(prose);
+  });
+
+  it("frame with lineCount === 0 is ignored", () => {
+    const original = `Hello world`;
+    const { frames } = scanToFrames(original, 9.6, 18);
+    // Even if we hand-add a frame with lineCount 0, it should not render
+    const fakeFrame = {
+      id: "fake-1",
+      x: 0, y: 0, w: 48, h: 54,
+      z: 0,
+      children: [],
+      content: null,
+      clip: true,
+      dirty: false,
+      gridRow: 0, gridCol: 0,
+      gridW: 5, gridH: 3,
+      docOffset: 0,
+      lineCount: 0, // not placed
+    };
+    const result = serializeUnified(original, [...frames, fakeFrame]);
+    expect(result).toBe("Hello world");
+  });
+});

--- a/src/serializeUnified.ts
+++ b/src/serializeUnified.ts
@@ -7,7 +7,7 @@ import { repairJunctions } from "./gridSerialize";
 /**
  * Serialize the unified CM doc back to a .md file.
  *
- * @param doc - The CM doc text (prose lines preserved; wireframe lines contain " ")
+ * @param doc - The CM doc text (prose lines preserved; wireframe lines are "")
  * @param frames - Top-level frames with gridRow + lineCount set
  * @returns The reconstructed .md text
  */

--- a/src/serializeUnified.ts
+++ b/src/serializeUnified.ts
@@ -1,0 +1,106 @@
+// src/serializeUnified.ts
+// Single-pass serialization for the unified document model.
+
+import type { Frame } from "./frame";
+import { repairJunctions } from "./gridSerialize";
+
+/**
+ * Serialize the unified CM doc back to a .md file.
+ *
+ * @param doc - The CM doc text (prose lines preserved; wireframe lines contain " ")
+ * @param frames - Top-level frames with gridRow + lineCount set
+ * @returns The reconstructed .md text
+ */
+export function serializeUnified(doc: string, frames: Frame[]): string {
+  if (!doc) return "";
+
+  const docLines = doc.split("\n");
+
+  // Map: source line index → frames claiming that line.
+  // Use gridRow directly — it is the absolute line number, invariant across
+  // doc content changes (wireframe lines being replaced with " ").
+  const lineToFrames = buildLineToFrames(frames);
+
+  // Walk doc lines and build output.
+  const outputLines = buildOutputLines(docLines, lineToFrames);
+
+  // Repair junctions where frame borders meet.
+  const grid = outputLines.map(line => [...line]);
+  repairJunctions(grid);
+
+  const result = grid.map(row => row.join("").trimEnd());
+  while (result.length > 0 && result[result.length - 1] === "") result.pop();
+  return result.join("\n");
+}
+
+/** Build a map from absolute line index → frames that claim that line.
+ * Uses gridRow directly — the absolute line number in the document. */
+function buildLineToFrames(frames: Frame[]): Map<number, Frame[]> {
+  const map = new Map<number, Frame[]>();
+  for (const f of frames) {
+    if (f.lineCount === 0) continue;
+    for (let i = 0; i < f.lineCount; i++) {
+      const ln = f.gridRow + i;
+      if (!map.has(ln)) map.set(ln, []);
+      map.get(ln)!.push(f);
+    }
+  }
+  return map;
+}
+
+/** Build output lines by walking doc lines and rendering claimed ones. */
+function buildOutputLines(
+  docLines: string[],
+  lineToFrames: Map<number, Frame[]>,
+): string[] {
+  const output: string[] = [];
+  for (let i = 0; i < docLines.length; i++) {
+    const claimingFrames = lineToFrames.get(i);
+    if (!claimingFrames || claimingFrames.length === 0) {
+      output.push(docLines[i]);
+      continue;
+    }
+    // Wireframe line — render frame cells at this row.
+    const rowChars: string[] = [];
+    for (const f of claimingFrames) {
+      const localRow = i - f.gridRow;
+      renderFrameRow(f, localRow, f.gridCol, rowChars);
+    }
+    output.push(rowChars.join("").trimEnd());
+  }
+  return output;
+}
+
+/**
+ * Render one row of a frame (and its children) into the rowChars array.
+ * localRow is relative to the frame's own top (0 = first row of the frame).
+ * colOffset is the absolute column where this frame starts.
+ */
+function renderFrameRow(
+  frame: Frame,
+  localRow: number,
+  colOffset: number,
+  rowChars: string[],
+): void {
+  if (localRow < 0 || localRow >= frame.gridH) return;
+
+  if (frame.content) {
+    for (const [key, ch] of frame.content.cells) {
+      const ci = key.indexOf(",");
+      const cellRow = Number(key.slice(0, ci));
+      const cellCol = Number(key.slice(ci + 1));
+      if (cellRow === localRow) {
+        const absCol = colOffset + cellCol;
+        while (rowChars.length <= absCol) rowChars.push(" ");
+        if (ch !== " " || rowChars[absCol] === " ") {
+          rowChars[absCol] = ch;
+        }
+      }
+    }
+  }
+
+  for (const child of frame.children) {
+    const childLocalRow = localRow - child.gridRow;
+    renderFrameRow(child, childLocalRow, colOffset + child.gridCol, rowChars);
+  }
+}

--- a/src/serializeUnified.ts
+++ b/src/serializeUnified.ts
@@ -82,9 +82,13 @@ function renderFrameRow(
   colOffset: number,
   rowChars: string[],
 ): void {
-  if (localRow < 0 || localRow >= frame.gridH) return;
-
-  if (frame.content) {
+  // Render this frame's own content only when localRow falls within its bounds.
+  // BUT always recurse to children — the scanner's reparenter sometimes places
+  // text labels at gridRow values that exceed their parent rect's gridH (e.g.
+  // junction-grid: "Bottom L" lives on a row shared with a sibling rect's
+  // border, technically OUTSIDE the parent rect). Each child has its own
+  // gridH check, so an unconditional recursion is safe.
+  if (localRow >= 0 && localRow < frame.gridH && frame.content) {
     for (const [key, ch] of frame.content.cells) {
       const ci = key.indexOf(",");
       const cellRow = Number(key.slice(0, ci));
@@ -99,6 +103,12 @@ function renderFrameRow(
     }
   }
 
+  // Always recurse — the scanner sometimes places child text frames at
+  // gridRow values that exceed their parent rect's gridH (e.g. junction
+  // grids: a label "Bottom L" can be a child of frame-1 with gridRow=3 even
+  // though frame-1 has gridH=3, because the label sits on a row shared with
+  // a sibling rect's top border). Each child's own gridH check inside the
+  // recursive call handles bounds — we mustn't prune here.
   for (const child of frame.children) {
     const childLocalRow = localRow - child.gridRow;
     renderFrameRow(child, childLocalRow, colOffset + child.gridCol, rowChars);


### PR DESCRIPTION
## Summary

Implements the unified document model from `docs/plans/2026-04-27-unified-document-impl.md`. The CM doc holds the full `.md` text including empty placeholder lines for wireframes; frames claim line ranges via `docOffset` + `lineCount`. Replaces the split prose/wireframe pipeline.

## What works

- **Initial load + render:** wireframes appear at correct positions, prose flows around them.
- **Save round-trip:** byte-equivalent for unedited docs.
- **Prose typing + Enter/Backspace** above/below wireframes (frame docOffset shifts correctly via `mapPos`).
- **Cursor can't land on wireframe rows** (`changeFilter` rejects + cursor naturally skips empty claimed lines).
- **Drag wireframe vertically** without scrambling prose. Implemented as **newline rotation** — frame absorbs adjacent empty lines instead of pushing past prose. Doc length is invariant under drag. Clamped no-op if no buffer.
- **Resize wireframe** (insert/remove claimed lines).
- **Delete wireframe** (removes claimed lines + one boundary newline; prose-above and prose-below join with single newline).
- **Arrow keys skip claimed line ranges** (Task 14, while-loop for adjacent frames).

## Architecture invariants

- For top-level frames, `gridRow` is a CACHE of `state.doc.lineAt(docOffset).number - 1`. `framesField.update` re-derives `gridRow` from `docOffset` after every doc-changing transaction — eliminates desync.
- Claimed lines in the CM doc are `""` (empty), not `" "` (single space). `preparedCache.ts:12` maps empty → `null` for the `reflowLayout` fast-path.
- `serializeUnified` always recurses into children regardless of parent `gridH` — the scanner reparenter sometimes places child labels at gridRow values that exceed parent bounds (e.g. junction grids), and unconditional recursion handles those.
- `unifiedDocSync` transactionFilter merges into one CM transaction so undo reverses doc + frame changes atomically. Skips re-applying `changeFilter` to programmatic emits.

## Known follow-ups (8 e2e harness failures)

| Cluster | Tests | Severity |
|---|---|---|
| Add new frame doesn't serialize | `add: draw new rect`, `ux: add wireframe to empty doc`, `add rect → move it`, `move frame, add new rect via tool` | HIGH — drawing new wireframes is a primary feature |
| Undo doesn't fully restore | `undo: resize then undo`, `undo: move-resize-undo-undo` | MEDIUM — silent data drift |
| Backspace-merge near wireframe | `Backspace merges line above wireframe, frame shifts up` | LOW–MEDIUM |
| L-path TypeError | `drag box right, save, drag same box down — L-path` | HIGH if interactively reproducible — JS crash |

Vitest: 480 pass / 5 skipped / 0 fail.
e2e harness: 117 pass / 8 fail (down from 21 fail before this branch).

## Test plan

- [x] `npm test` passes
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] `npx playwright test e2e/harness.spec.ts` — 117/125 pass, 8 known failures listed above
- [x] Manual smoke test on http://localhost:5177/gridpad/: drag, type, Enter, save, click-into-wireframe-rejected all work
- [ ] Add-frame cluster fixes
- [ ] Undo cluster fixes
- [ ] L-path crash investigated

## Commits worth highlighting

- `22dfb5b` derive top-level gridRow from docOffset (single source of truth)
- `6bbbaa1` serializeUnified always recurses into children regardless of parent gridH
- `317f90a` drag wireframe via newline rotation (preserves doc length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)